### PR TITLE
Ensure rocksdb test directories are created/deleted

### DIFF
--- a/src/test/java/com/jwplayer/southpaw/SouthpawEndToEndTest.java
+++ b/src/test/java/com/jwplayer/southpaw/SouthpawEndToEndTest.java
@@ -23,12 +23,15 @@ import com.jwplayer.southpaw.util.ByteArray;
 import com.jwplayer.southpaw.util.FileHelper;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.yaml.snakeyaml.Yaml;
 
+import java.io.File;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -36,6 +39,7 @@ import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class SouthpawEndToEndTest {
+    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
     private static final String CONFIG_PATH = "test-resources/config.sample.yaml";
     private static final String RELATIONS_PATH = "test-resources/relations.sample.json";
     private static final String RELATIONS_PATH2 = "test-resources/relations2.sample.json";
@@ -58,6 +62,9 @@ public class SouthpawEndToEndTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> getTestCases() throws Exception {
+        // call setup function since parameter cases are setup prior to @Before being called
+        setup();
+
         // Build the expected results
         ObjectMapper mapper = new ObjectMapper();
         Map<ByteArray, DenormalizedRecord> expectedResults = new HashMap<>(12);
@@ -133,6 +140,18 @@ public class SouthpawEndToEndTest {
 
         assertEquals(12, retVal.size());
         return retVal;
+    }
+
+    public static void setup() throws URISyntaxException {
+        // This setup function is called manually within the parameterized test cases
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.mkdirs();
+    }
+
+    @After
+    public void cleanup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.delete();
     }
 
     @Test

--- a/src/test/java/com/jwplayer/southpaw/SouthpawTest.java
+++ b/src/test/java/com/jwplayer/southpaw/SouthpawTest.java
@@ -23,18 +23,19 @@ import com.jwplayer.southpaw.record.MapRecord;
 import com.jwplayer.southpaw.topic.BaseTopic;
 import com.jwplayer.southpaw.util.ByteArray;
 import com.jwplayer.southpaw.util.FileHelper;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.yaml.snakeyaml.Yaml;
 
+import java.io.File;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 
 import static org.junit.Assert.*;
 
 
 public class SouthpawTest {
+    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
     private static final String BROKEN_RELATIONS_PATH = "test-resources/broken_relations.sample.json";
     private static final String CONFIG_PATH = "test-resources/config.sample.yaml";
     private static final String RELATIONS_PATH = "test-resources/relations.sample.json";
@@ -43,6 +44,18 @@ public class SouthpawTest {
     private Map<String, Object> config;
     private MockSouthpaw southpaw;
     private URI relationsUri;
+
+    @BeforeClass
+    public static void classSetup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.mkdirs();
+    }
+
+    @AfterClass
+    public static void classCleanup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.delete();
+    }
 
     @Before
     public void setup() throws Exception {

--- a/src/test/java/com/jwplayer/southpaw/index/MultiIndexTest.java
+++ b/src/test/java/com/jwplayer/southpaw/index/MultiIndexTest.java
@@ -25,19 +25,38 @@ import com.jwplayer.southpaw.topic.InMemoryTopic;
 import com.jwplayer.southpaw.util.ByteArray;
 import com.jwplayer.southpaw.util.FileHelper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TestName;
 
+import java.io.File;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 
 import static org.junit.Assert.*;
 
 
 public class MultiIndexTest {
+    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
+
     protected MultiIndex<BaseRecord, BaseRecord> index;
     protected RocksDBState state;
+
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @BeforeClass
+    public static void classSetup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.mkdirs();
+    }
+
+    @AfterClass
+    public static void classCleanup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.delete();
+    }
 
     @Before
     public void setup() {
@@ -51,7 +70,7 @@ public class MultiIndexTest {
     }
 
     private MultiIndex<BaseRecord, BaseRecord> createEmptyIndex(RocksDBState state) {
-        Map<String, Object> config = RocksDBStateTest.createConfig("file:///tmp/RocksDB/MultiSimpleIndexTest");
+        Map<String, Object> config = RocksDBStateTest.createConfig(ROCKSDB_BASE_URI + testName);
         config.put(MultiIndex.INDEX_LRU_CACHE_SIZE, 2);
         config.put(MultiIndex.INDEX_WRITE_BATCH_SIZE, 5);
         JsonSerde keySerde = new JsonSerde();

--- a/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
+++ b/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
@@ -16,10 +16,11 @@
 package com.jwplayer.southpaw.state;
 
 import com.jwplayer.southpaw.util.ByteArray;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +29,8 @@ import static org.junit.Assert.*;
 
 
 public class RocksDBStateTest {
+    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
+
     protected static final String BACKUP_URI = "file:///tmp/RocksDB/RocksDBStateTestBackup";
     protected static final String KEY_SPACE = "Default";
     protected static final String URI = "file:///tmp/RocksDB/RocksDBStateTest";
@@ -44,6 +47,18 @@ public class RocksDBStateTest {
         config.put(RocksDBState.PUT_BATCH_SIZE, 5);
         config.put(RocksDBState.URI_CONFIG, uri);
         return config;
+    }
+
+    @BeforeClass
+    public static void classSetup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.mkdirs();
+    }
+
+    @AfterClass
+    public static void classCleanup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.delete();
     }
 
     @Before

--- a/src/test/java/com/jwplayer/southpaw/topic/ConsoleTopicTest.java
+++ b/src/test/java/com/jwplayer/southpaw/topic/ConsoleTopicTest.java
@@ -22,21 +22,40 @@ import com.jwplayer.southpaw.state.RocksDBStateTest;
 import com.jwplayer.southpaw.util.ByteArray;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.kafka.common.serialization.Serdes;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TestName;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 
 public class ConsoleTopicTest {
+    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
+
     BaseState state;
     public ConsoleTopic<String, String> topic;
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @BeforeClass
+    public static void classSetup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.mkdirs();
+    }
+
+    @AfterClass
+    public static void classCleanup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.delete();
+    }
 
     @Before
     public void setUp() {
         topic = new ConsoleTopic<>();
-        Map<String, Object> config = RocksDBStateTest.createConfig("file:///tmp/RocksDB/ConsoleTopicTest");
+        Map<String, Object> config = RocksDBStateTest.createConfig(ROCKSDB_BASE_URI + testName);
         state = new RocksDBState();
         state.configure(config);
         topic.configure("TestTopic", config, state, Serdes.String(), Serdes.String(), new DefaultFilter());

--- a/src/test/java/com/jwplayer/southpaw/topic/InMemoryTopicTest.java
+++ b/src/test/java/com/jwplayer/southpaw/topic/InMemoryTopicTest.java
@@ -21,10 +21,12 @@ import com.jwplayer.southpaw.state.RocksDBStateTest;
 import com.jwplayer.southpaw.util.ByteArray;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serdes;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TestName;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -33,13 +35,31 @@ import static org.junit.Assert.*;
 
 
 public class InMemoryTopicTest {
+    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
+
     private final String[] keys = {"A", "B", "C"};
     private final String[] values = {"Badger", "Mushroom", "Snake"};
     private RocksDBState state;
 
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @BeforeClass
+    public static void classSetup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.mkdirs();
+    }
+
+    @AfterClass
+    public static void classCleanup() throws URISyntaxException {
+        File folder = new File(new URI(ROCKSDB_BASE_URI));
+        folder.delete();
+    }
+
     @Before
     public void setup() {
-        Map<String, Object> config = RocksDBStateTest.createConfig("file:///tmp/RocksDB/InMemoryTopicTest");
+        Map<String, Object> config = RocksDBStateTest.createConfig(ROCKSDB_BASE_URI + testName);
         state = new RocksDBState();
         state.configure(config);
     }


### PR DESCRIPTION
- Removes an assumption in tests that `/tmp/RocksDB` directory exists by creating and removing the directory before and after tests are run

Tested against the following test cases to ensure they pass and the directory doesn't exist afterwards

- Test all`mvn test`
- Test class `mvn -Dtest=KafkaTopicTesttest`
- Test individual `mvn -Dtest=KafkaTopicTest#testGetCurrentOffsetAfterRead test`