### PR TITLE
Bump the jackson versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: false
 language: java
+cache:
+  directories:
+    - $HOME/.m2/repository
 jdk:
   - openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-                <version>0.4.37</version>
+                <version>1.0.0</version>
                 <configuration>
                     <sourceDirectory>${basedir}/src/main/resources/southpaw/schema</sourceDirectory>
                     <targetPackage>com.jwplayer.southpaw.json</targetPackage>


### PR DESCRIPTION
- Bumps jackson and jsonschema2pojo in order to pull in newer jackson versions to avoid security vulnerabilities in jackson < 2.9.5
- Enable maven dep caching on travisCI