### PR TITLE
Fix column family handle lingering pointers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
-            <version>5.10.3</version>
+            <version>5.17.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This change modifies the way we are keeping track of RocksDB column family handlers in order to ensure we are properly cleaning up all open handlers prior to closing the database in order to avoid crashes on OSX. Bumps the version of RocksDB in order to gain access to newer exposed JNI hooks

This PR fixed #9 