### PR TITLE
cleanup tests that write to disk

### DIFF
--- a/src/test/java/com/jwplayer/southpaw/MockState.java
+++ b/src/test/java/com/jwplayer/southpaw/MockState.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Longtail Ad Solutions (DBA JW Player)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jwplayer.southpaw;
+
+import com.jwplayer.southpaw.state.BaseState;
+import com.jwplayer.southpaw.util.ByteArray;
+import org.apache.commons.lang.NotImplementedException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MockState extends BaseState {
+
+    private Map<ByteArray, Map<ByteArray, byte[]>> dataBatches;
+
+    @Override
+    public void backup() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void close() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void configure(Map<String, Object> config) {
+        dataBatches = new HashMap<>();
+    }
+
+    @Override
+    public void createKeySpace(String keySpace) {
+        dataBatches.put(new ByteArray(keySpace), new HashMap<>());
+    }
+
+    @Override
+    public void delete() {
+        dataBatches.clear();
+    }
+
+    @Override
+    public void delete(String keySpace, byte[] key) {
+        dataBatches.get(new ByteArray(keySpace)).remove(new ByteArray(key));
+    }
+
+    @Override
+    public void deleteBackups() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void flush(String keySpace) {
+
+    }
+
+    @Override
+    public byte[] get(String keySpace, byte[] key) {
+       return dataBatches.get(new ByteArray(keySpace)).get(new ByteArray(key));
+    }
+
+    @Override
+    public Iterator iterate(String keySpace) {
+        return null;
+    }
+
+    @Override
+    public void put(String keySpace, byte[] key, byte[] value) {
+        Map<ByteArray, byte[]> dataBatch = dataBatches.get(new ByteArray(keySpace));
+        dataBatch.put(new ByteArray(key), value);
+    }
+
+    @Override
+    public void restore() {
+        throw new NotImplementedException();
+    }
+}

--- a/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
+++ b/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
@@ -16,11 +16,10 @@
 package com.jwplayer.southpaw.state;
 
 import com.jwplayer.southpaw.util.ByteArray;
-import org.apache.commons.io.FileUtils;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -34,44 +33,36 @@ import static org.junit.Assert.*;
 
 
 public class RocksDBStateTest {
-    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
+    private static final String KEY_SPACE = "Default";
 
-    protected static final String BACKUP_URI = "file:///tmp/RocksDB/RocksDBStateTestBackup";
-    protected static final String KEY_SPACE = "Default";
-    protected static final String URI = "file:///tmp/RocksDB/RocksDBStateTest";
+    private RocksDBState state;
 
-    protected RocksDBState state;
-
-    public static Map<String, Object> createConfig(String uri) {
+    private static Map<String, Object> createConfig(String dbUri, String backupUri) {
         Map<String, Object> config = new HashMap<>();
-        config.put(RocksDBState.BACKUP_URI_CONFIG, BACKUP_URI);
+        config.put(RocksDBState.BACKUP_URI_CONFIG, backupUri);
         config.put(RocksDBState.BACKUPS_TO_KEEP_CONFIG, 5);
         config.put(RocksDBState.COMPACTION_READ_AHEAD_SIZE_CONFIG, 1048675);
         config.put(RocksDBState.MEMTABLE_SIZE, 1048675);
         config.put(RocksDBState.PARALLELISM_CONFIG, 4);
         config.put(RocksDBState.PUT_BATCH_SIZE, 5);
-        config.put(RocksDBState.URI_CONFIG, uri);
+        config.put(RocksDBState.URI_CONFIG, dbUri);
         return config;
     }
 
+    @Rule
+    public TemporaryFolder dbFolder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder backupFolder = new TemporaryFolder();
+
     @Rule public ExpectedException thrown = ExpectedException.none();
-
-    @BeforeClass
-    public static void classSetup() throws URISyntaxException, IOException {
-        File folder = new File(new URI(ROCKSDB_BASE_URI));
-        FileUtils.deleteDirectory(folder);
-        folder.mkdirs();
-    }
-
-    @AfterClass
-    public static void classCleanup() throws URISyntaxException, IOException {
-        FileUtils.deleteDirectory(new File(new URI(ROCKSDB_BASE_URI)));
-    }
 
     @Before
     public void setUp() {
+        String dbUri = dbFolder.getRoot().toURI().toString();
+        String backupUri = backupFolder.getRoot().toURI().toString();
         state = new RocksDBState();
-        state.configure(createConfig(URI));
+        state.configure(createConfig(dbUri, backupUri));
         state.createKeySpace(KEY_SPACE);
         writeData(0,100);
     }
@@ -190,7 +181,7 @@ public class RocksDBStateTest {
     }
 
     private void corruptLatestSST() throws URISyntaxException, IOException {
-        Path dir = Paths.get(new URI(BACKUP_URI + "/shared"));
+        Path dir = Paths.get(new URI(backupFolder.getRoot().toURI().toString() + "/shared"));
         Optional<Path> lastFilePath = Files.list(dir)
                 .filter(f -> !Files.isDirectory(f))
                 .max(Comparator.naturalOrder());

--- a/src/test/java/com/jwplayer/southpaw/topic/ConsoleTopicTest.java
+++ b/src/test/java/com/jwplayer/southpaw/topic/ConsoleTopicTest.java
@@ -15,49 +15,27 @@
  */
 package com.jwplayer.southpaw.topic;
 
-import com.jwplayer.southpaw.filter.DefaultFilter;
-import com.jwplayer.southpaw.state.BaseState;
-import com.jwplayer.southpaw.state.RocksDBState;
-import com.jwplayer.southpaw.state.RocksDBStateTest;
+import com.jwplayer.southpaw.MockState;
+import com.jwplayer.southpaw.filter.BaseFilter;
 import com.jwplayer.southpaw.util.ByteArray;
-import com.jwplayer.southpaw.topic.TopicConfig;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.*;
-import org.junit.rules.TestName;
 
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 
 
 public class ConsoleTopicTest {
-    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
+    private MockState state;
+    private ConsoleTopic<String, String> topic;
 
-    BaseState state;
-    public ConsoleTopic<String, String> topic;
-
-    @Rule
-    public TestName testName = new TestName();
-
-    @BeforeClass
-    public static void classSetup() throws URISyntaxException {
-        File folder = new File(new URI(ROCKSDB_BASE_URI));
-        folder.mkdirs();
-    }
-
-    @AfterClass
-    public static void classCleanup() throws URISyntaxException {
-        File folder = new File(new URI(ROCKSDB_BASE_URI));
-        folder.delete();
-    }
 
     @Before
     public void setUp() {
         topic = new ConsoleTopic<>();
-        Map<String, Object> config = RocksDBStateTest.createConfig(ROCKSDB_BASE_URI + testName);
-        state = new RocksDBState();
+        Map<String, Object> config = new HashMap<>();
+        state = new MockState();
         state.configure(config);
         topic.configure(new TopicConfig<String, String>()
             .setShortName("TestTopic")
@@ -65,7 +43,7 @@ public class ConsoleTopicTest {
             .setState(state)
             .setKeySerde(Serdes.String())
             .setValueSerde(Serdes.String())
-            .setFilter(new DefaultFilter()));
+            .setFilter(new BaseFilter()));
     }
 
     @After

--- a/src/test/java/com/jwplayer/southpaw/topic/InMemoryTopicTest.java
+++ b/src/test/java/com/jwplayer/southpaw/topic/InMemoryTopicTest.java
@@ -15,18 +15,14 @@
  */
 package com.jwplayer.southpaw.topic;
 
-import com.jwplayer.southpaw.filter.DefaultFilter;
-import com.jwplayer.southpaw.state.RocksDBState;
-import com.jwplayer.southpaw.state.RocksDBStateTest;
+import com.jwplayer.southpaw.MockState;
+import com.jwplayer.southpaw.filter.BaseFilter;
+import com.jwplayer.southpaw.state.BaseState;
 import com.jwplayer.southpaw.util.ByteArray;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.*;
-import org.junit.rules.TestName;
 
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -35,33 +31,14 @@ import static org.junit.Assert.*;
 
 
 public class InMemoryTopicTest {
-    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
-
     private final String[] keys = {"A", "B", "C"};
     private final String[] values = {"Badger", "Mushroom", "Snake"};
-    private RocksDBState state;
-
-
-    @Rule
-    public TestName testName = new TestName();
-
-    @BeforeClass
-    public static void classSetup() throws URISyntaxException {
-        File folder = new File(new URI(ROCKSDB_BASE_URI));
-        folder.mkdirs();
-    }
-
-    @AfterClass
-    public static void classCleanup() throws URISyntaxException {
-        File folder = new File(new URI(ROCKSDB_BASE_URI));
-        folder.delete();
-    }
+    private BaseState state;
 
     @Before
     public void setup() {
-        Map<String, Object> config = RocksDBStateTest.createConfig(ROCKSDB_BASE_URI + testName);
-        state = new RocksDBState();
-        state.configure(config);
+        state = new MockState();
+        state.configure(new HashMap<>());
     }
 
     @After
@@ -78,7 +55,7 @@ public class InMemoryTopicTest {
             .setState(state)
             .setKeySerde(Serdes.String())
             .setValueSerde(Serdes.String())
-            .setFilter(new DefaultFilter()));
+            .setFilter(new BaseFilter()));
 
         for(int i = 0; i < keys.length; i++) {
             topic.write(keys[i], values[i]);

--- a/src/test/java/com/jwplayer/southpaw/topic/KafkaTopicTest.java
+++ b/src/test/java/com/jwplayer/southpaw/topic/KafkaTopicTest.java
@@ -15,20 +15,16 @@
  */
 package com.jwplayer.southpaw.topic;
 
-import com.jwplayer.southpaw.filter.DefaultFilter;
-import com.jwplayer.southpaw.state.RocksDBState;
-import com.jwplayer.southpaw.state.RocksDBStateTest;
+import com.jwplayer.southpaw.MockState;
+import com.jwplayer.southpaw.filter.BaseFilter;
+import com.jwplayer.southpaw.state.BaseState;
 import com.jwplayer.southpaw.util.ByteArray;
 import com.jwplayer.southpaw.util.KafkaTestServer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.*;
-import org.junit.rules.TestName;
 
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -37,11 +33,10 @@ import static org.junit.Assert.*;
 
 
 public class KafkaTopicTest {
-    private static final String ROCKSDB_BASE_URI = "file:///tmp/RocksDB/";
     private static final String TEST_TOPIC = "test-topic";
 
     private KafkaTestServer kafkaServer;
-    private RocksDBState state;
+    private BaseState state;
     private KafkaTopic<String, String> topic;
 
     public KafkaTopic<String, String> createTopic(String topicName) {
@@ -58,7 +53,7 @@ public class KafkaTopicTest {
             .setState(state)
             .setKeySerde(Serdes.String())
             .setValueSerde(Serdes.String())
-            .setFilter(new DefaultFilter()));
+            .setFilter(new BaseFilter()));
 
         topic.write("A", "1");
         topic.write("B", "2");
@@ -67,26 +62,10 @@ public class KafkaTopicTest {
         return topic;
     }
 
-    @Rule public TestName testName = new TestName();
-
-    @BeforeClass
-    public static void classSetup() throws URISyntaxException {
-        File folder = new File(new URI(ROCKSDB_BASE_URI));
-        folder.mkdirs();
-    }
-
-    @AfterClass
-    public static void classCleanup() throws URISyntaxException {
-        File folder = new File(new URI(ROCKSDB_BASE_URI));
-        folder.delete();
-    }
-
     @Before
     public void setup() {
-        state = new RocksDBState();
-
-        Map<String, Object> config = RocksDBStateTest.createConfig(ROCKSDB_BASE_URI + testName);
-        state.configure(config);
+        state = new MockState();
+        state.configure(new HashMap<>());
         kafkaServer = new KafkaTestServer();
         topic = createTopic(TEST_TOPIC);
     }


### PR DESCRIPTION
- Adds a class for mocking State in memory
- Modifies tests outside RocksDbState and integration tests from needing to persist to rocksdb
- Makes use of jUnit temp files for better test isolation and cleanup
- Switches tests that were using the deprecated `DefaultFilter` to use the `BaseFilter` class
