### PR TITLE
Remove unnecessary curator-framework dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,12 +130,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
-            <version>2.12.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <version>2.12.0</version>
             <scope>test</scope>

--- a/src/test/java/com/jwplayer/southpaw/util/ZookeeperTestServer.java
+++ b/src/test/java/com/jwplayer/southpaw/util/ZookeeperTestServer.java
@@ -19,24 +19,17 @@ import kafka.utils.ZKStringSerializer$;
 import kafka.utils.ZkUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.ZkConnection;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.apache.curator.framework.imps.CuratorFrameworkState;
 
 import java.io.IOException;
 
 
 public class ZookeeperTestServer {
-    private CuratorFramework zookeeperTestServer;
     private TestingServer testingServer;
 
     public ZookeeperTestServer() {
         try {
             testingServer = new TestingServer();
-            ExponentialBackoffRetry backoffRetry = new ExponentialBackoffRetry(1000, 4);
-            zookeeperTestServer = CuratorFrameworkFactory.newClient(getConnectionString(), backoffRetry);
         } catch (Exception ex) {
             throw new RuntimeException("Couldn't start test ZK server", ex);
         }
@@ -53,9 +46,6 @@ public class ZookeeperTestServer {
 
     public void shutdown() {
         try {
-            if (zookeeperTestServer.getState().equals(CuratorFrameworkState.STARTED)) {
-                zookeeperTestServer.close();
-            }
             testingServer.close();
         } catch (IOException ex) {
             throw new RuntimeException("Couldn't shutdown test ZK server", ex);


### PR DESCRIPTION
This dependency isn't actually in use. We were attemtping to start an additional Zookeeper server during testing. We should just need to include `curator-test` dependency which includes `TestingServer`