### PR TITLE
Extend optional restore methods support

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -911,6 +911,7 @@ public class Southpaw {
                 restore();
             case RestoreMode.WHEN_NEEDED:
                 if (state.needsRestore()) {
+                    logger.info("State not found locally. Attempting to restore state from backups");
                     restore();
                 } else {
                     logger.info("State already exists. Skipping restore");

--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -809,15 +809,24 @@ public class Southpaw {
 
         OptionParser parser = new OptionParser() {
             {
-                accepts(CONFIG, "Path to the Southpaw config file").withRequiredArg().required();
-                accepts(RELATIONS, "Paths to one or more files containing input record relations").withRequiredArg().required();
+                accepts(CONFIG, "Path to the Southpaw config file")
+                        .withRequiredArg()
+                        .required();
+                accepts(RELATIONS, "Paths to one or more files containing input record relations")
+                        .withRequiredArg()
+                        .required();
                 accepts(BUILD, "Builds denormalized records using an existing state.");
                 accepts(DELETE_BACKUP, "Deletes existing backups specified in the config file. BE VERY CAREFUL WITH THIS!!!");
                 accepts(DELETE_STATE, "Deletes the existing state specified in the config file. BE VERY CAREFUL WITH THIS!!!");
-                accepts(RESTORE, "Restores the state from existing backups.");
-                accepts(RESTORE_MODE, "Specifies when state restores should run. One of: never|always|when_needed Defaults to: never").withOptionalArg().ofType(String.class).defaultsTo(RestoreMode.NEVER);
-                accepts(DEBUG, "Sets logging to DEBUG.").withOptionalArg();
-                accepts(HELP, "Since you are seeing this, you probably know what this is for. :)").forHelp();
+                accepts(RESTORE, "DEPRECATED: Restores the state from existing backups.");
+                accepts(RESTORE_MODE, "Specifies when state restores should run. One of: never|always|when_needed Defaults to: never")
+                        .withOptionalArg()
+                        .ofType(String.class)
+                        .defaultsTo(RestoreMode.NEVER);
+                accepts(DEBUG, "Sets logging to DEBUG.")
+                        .withOptionalArg();
+                accepts(HELP, "Since you are seeing this, you probably know what this is for. :)")
+                        .forHelp();
             }
         };
         OptionSet options = parser.parse(args);

--- a/src/main/java/com/jwplayer/southpaw/state/BaseState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/BaseState.java
@@ -116,4 +116,10 @@ public abstract class BaseState {
      * Restore the state from a previous backup.
      */
     public abstract void restore();
+
+    /**
+     * A check to see if a restore has been previously performed.
+     * @return True if a restore has not been performed yet.
+     */
+    public abstract boolean needsRestore();
 }

--- a/src/test/java/com/jwplayer/southpaw/MockState.java
+++ b/src/test/java/com/jwplayer/southpaw/MockState.java
@@ -91,4 +91,9 @@ public class MockState extends BaseState {
     public void restore() {
         throw new NotImplementedException();
     }
+
+    @Override
+    public boolean needsRestore() {
+        return false;
+    }
 }

--- a/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
+++ b/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
@@ -180,6 +180,18 @@ public class RocksDBStateTest {
         assertEquals("B", value);
     }
 
+    @Test
+    public void needsRestore() {
+        assertTrue(state.needsRestore());
+
+        state.backup();
+
+        state.restore();
+
+        assertFalse(state.needsRestore());
+
+    }
+
     private void corruptLatestSST() throws URISyntaxException, IOException {
         Path dir = Paths.get(new URI(backupFolder.getRoot().toURI().toString() + "/shared"));
         Optional<Path> lastFilePath = Files.list(dir)


### PR DESCRIPTION
- Deprecates the `--restore` flag in favor of `--restore-mode` which accepts `always|never|when_needed` options for handling different restore functionality
- Adds functionality for only restoring when a local db hasn't been restored from a backup