### PR TITLE
Fix potential memory leak when KafkaTopics.flush() isn't called often

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/topic/KafkaTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/KafkaTopic.java
@@ -327,9 +327,9 @@ public class KafkaTopic<K, V> extends BaseTopic<K, V> {
             producer.flush();
         }
 
-        long failedRecords = inflightRecords.get();
-        if(failedRecords != 0) {
-            throw new RuntimeException("Could not successfully flush " + failedRecords + " to the topic");
+        long count = inflightRecords.get();
+        if(count != 0) {
+            throw new RuntimeException("Could not successfully flush " + count + " records");
         }
 
         checkCallbackExceptions();
@@ -390,16 +390,12 @@ public class KafkaTopic<K, V> extends BaseTopic<K, V> {
     public void write(K key, V value) {
         checkCallbackExceptions();
 
-        if(producer == null) {
-            producer = new KafkaProducer<>(topicConfig.southpawConfig,
-                    this.getKeySerde().serializer(), this.getValueSerde().serializer());
-        }
+        if(producer == null) producer = new KafkaProducer<>(topicConfig.southpawConfig,
+                this.getKeySerde().serializer(), this.getValueSerde().serializer());
 
         inflightRecords.incrementAndGet();
 
         producer.send(new ProducerRecord<>(topicName, 0, key, value), producerCallback);
-
-        logger.info("There are " + inflightRecords.get() + " in flight records");
     }
 
     private void checkCallbackExceptions() throws RuntimeException {

--- a/src/main/java/com/jwplayer/southpaw/topic/KafkaTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/KafkaTopic.java
@@ -403,7 +403,7 @@ public class KafkaTopic<K, V> extends BaseTopic<K, V> {
         if (callbackException != null) {
             callbackException = null;
 
-            throw new RuntimeException("Failed to write record to Kafka: " + ex.getMessage(), ex);
+            throw new RuntimeException("Failed to write record to " + this.getShortName() + " topic: " + ex.getMessage(), ex);
         }
     }
 }


### PR DESCRIPTION
Currently we keep track of async writes to Kafka by keeping track of a list of futures and we check the status of these futures when we call `KafkaTopics.flush()`. Under certain conditions of heavy record streaming you could get into a case where `KafkaTopics.flush()` isn't called for a long period of time. When this happens the list of futures would continue to grow and could eventually lead to an OOM crash. Since the KafkaProducer keeps track of it's own buffer of records awaiting async writes, the records associated with the ever growing list of futures are often already complete but we just haven't checked them yet.

This change replaces the use of KafkaProducer futures with using a callback. In this case the callback can be acted upon as soon as the record write is complete(success or failure) and we can perform error handling / in flight record management right away rather than wait to explicitly check all futures.