### PR TITLE
Ensure RocksDB closes on exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ The config is broken up into multiple sections:
 ### Generic Config
 
 * log.level - The level to log at (e.g. INFO or DEBUG). In the future should just be replaced with a properties file.
-* backup.on.shutdown - Instruct Southpaw to backup on shutdown (or not)
 * backup.time.s - The amount of time in seconds between backups
 * commit.time.s - The amount of time in seconds between full state commits
 * create.records.trigger - Number of denormalized record create actions to queue before creating denormalized records. Only queues creation of records when lagging. 

--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -837,7 +837,11 @@ public class Southpaw {
         if(options.has(BUILD)) {
             Southpaw southpaw = new Southpaw(config, relURIs);
             southpaw.startedSuccessfully = true;
-            southpaw.run(0);
+            try{
+                southpaw.run(0);
+            } finally {
+                southpaw.close();
+            }
         }
     }
 

--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -134,10 +134,6 @@ public class Southpaw {
      */
     protected final Relation[] relations;
     /**
-     * Did Southpaw start up successfully?
-     */
-    protected boolean startedSuccessfully = false;
-    /**
      * State for Southpaw
      */
     protected BaseState state;
@@ -231,22 +227,6 @@ public class Southpaw {
         for (Relation root : relations) {
             byte[] bytes = state.get(METADATA_KEYSPACE, createDePKEntryName(root).getBytes());
             dePKsByType.put(root, ByteArraySet.deserialize(bytes));
-        }
-
-        /* Make sure we backup, and close before exiting. Also, prevents a scenario where Southpaw:
-        * - Starts up
-        * - Attempts to restore from backups
-        * - Restore fails, potentially due to a transient S3 error
-        * - Backup on shutdown is set to true
-        * - The new empty DB is backed up, overwriting the existing backups
-        * */
-        if(config.backupOnShutdown && startedSuccessfully) {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                logger.info("Backing up before shutting down");
-                this.state.backup();
-                this.close();
-                logger.info("Shutting down");
-            }));
         }
     }
 
@@ -836,7 +816,6 @@ public class Southpaw {
 
         if(options.has(BUILD)) {
             Southpaw southpaw = new Southpaw(config, relURIs);
-            southpaw.startedSuccessfully = true;
             try{
                 southpaw.run(0);
             } finally {

--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -265,8 +265,6 @@ public class RocksDBState extends BaseState {
             final BackupEngine backupEngine = BackupEngine.open(Env.getDefault(), backupOptions)) {
             backupEngine.createNewBackup(rocksDB, true);
             backupEngine.purgeOldBackups(backupsToKeep);
-        } finally {
-            logger.info("Shutting down RocksDB backup engine");
         }
     }
 
@@ -577,9 +575,8 @@ public class RocksDBState extends BaseState {
     }
 
     protected void putBatch(ByteArray keySpace) {
-        try {
-            Map<ByteArray, byte[]> dataBatch = dataBatches.get(keySpace);
-            WriteBatch writeBatch = new WriteBatch();
+        Map<ByteArray, byte[]> dataBatch = dataBatches.get(keySpace);
+        try (WriteBatch writeBatch = new WriteBatch()){
             for(Map.Entry<ByteArray, byte[]> batchEntry: dataBatch.entrySet()) {
                 writeBatch.put(
                         cfHandles.get(keySpace),
@@ -588,7 +585,6 @@ public class RocksDBState extends BaseState {
                 );
             }
             rocksDB.write(writeOptions, writeBatch);
-            writeBatch.close();
             dataBatch.clear();
         } catch(RocksDBException ex) {
             throw new RuntimeException(ex);

--- a/src/main/java/com/jwplayer/southpaw/util/S3Helper.java
+++ b/src/main/java/com/jwplayer/southpaw/util/S3Helper.java
@@ -285,6 +285,7 @@ public class S3Helper {
         waitForSyncToS3();
         syncToS3Future = executor.submit(() -> {
             try {
+                logger.info("Initiating background sync to S3");
                 try(Timer.Context context = metrics.s3Uploads.time()) {
                     Preconditions.checkNotNull(localUri);
                     Preconditions.checkArgument(localUri.getScheme() == null || FileHelper.SCHEME.equalsIgnoreCase(localUri.getScheme()));
@@ -389,13 +390,16 @@ public class S3Helper {
                     logger.warn("Unhandled exception during sync to S3", ex);
                 }
             }
+            logger.info("Background sync to S3 complete");
         });
     }
 
     protected void waitForSyncToS3() throws InterruptedException, ExecutionException {
         if(syncToS3Future != null) {
+            logger.info("Blocking for existing sync to S3 to complete");
             syncToS3Future.get();
             syncToS3Future = null;
+            logger.info("Existing sync to S3 complete");
         }
     }
 }

--- a/src/main/java/com/jwplayer/southpaw/util/S3Helper.java
+++ b/src/main/java/com/jwplayer/southpaw/util/S3Helper.java
@@ -283,9 +283,9 @@ public class S3Helper {
      */
     public void syncToS3(URI localUri, URI s3Uri) throws InterruptedException, ExecutionException {
         waitForSyncToS3();
+        logger.info("Initiating background sync to S3");
         syncToS3Future = executor.submit(() -> {
             try {
-                logger.info("Initiating background sync to S3");
                 try(Timer.Context context = metrics.s3Uploads.time()) {
                     Preconditions.checkNotNull(localUri);
                     Preconditions.checkArgument(localUri.getScheme() == null || FileHelper.SCHEME.equalsIgnoreCase(localUri.getScheme()));


### PR DESCRIPTION
- Wraps Southpaw.run() in a try/finally block and calls Southpaw.close() on exception to ensure state closes.
- Moves some function scoped references of RocksDB native resources into a try/closable block to ensure they are closed upon function exit.
- Adds some logging around backups / s3 
- Remove shutdown hook and `backup.on.shutdown` config option. This functionality was broken for the following reasons:
1. The conditional to set the shutdown hook couldn't ever be met
2. If it was able to be hit, RocksDBState class would except out because currently it is not thread safe and the shutdown hook happens on a background thread. 
3. Backups when pointing to S3 would most likely never finish in time and a partial backup could be worse than no backup.