### PR TITLE
Fixes #37 shutdown s3helper threadpools when shutting down RocksDbState instances

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -289,6 +289,10 @@ public class RocksDBState extends BaseState {
         flushOptions = null;
         writeOptions = null;
         rocksDB = null;
+
+        if (s3Helper != null) {
+            s3Helper.close();
+        }
     }
 
     @Override

--- a/src/test/java/com/jwplayer/southpaw/util/S3HelperTest.java
+++ b/src/test/java/com/jwplayer/southpaw/util/S3HelperTest.java
@@ -63,7 +63,7 @@ public class S3HelperTest {
         client.putObject(s3Uri.getHost(), prefix + "/fileA.txt", "ABCD");
         client.putObject(s3Uri.getHost(), prefix + "/fileB.txt", "1234");
         client.putObject(s3Uri.getHost(), prefix + "/fileC.txt", "AB34");
-        s3 = new S3Helper(client);
+        s3 = new S3Helper(new HashMap<>(), client);
     }
 
     @After


### PR DESCRIPTION
- Adds a `S3Helper.close()` to close ExecutorService and S3 client instances
- Modifies the S3Helper test fixture constructor to pass in a config map in order to be able to set exceptOnException config option. Unifies both constructors so tests can be added to this config option in the future

closes #37 