### PR TITLE
Keep track of and close all iterators on RocksDBState close

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -147,6 +147,7 @@ public class RocksDBState extends BaseState {
      * Configuration for this state
      */
     protected Map<String, Object> config;
+    private List<Iterator> iterators = new ArrayList<>();
     /**
      * Max # of background compactions
      */
@@ -274,6 +275,10 @@ public class RocksDBState extends BaseState {
             return;
         }
         super.close();
+
+        for (Iterator iterator : iterators) {
+            iterator.close();
+        }
 
         for(Map.Entry<ByteArray, ColumnFamilyHandle> entry: cfHandles.entrySet()) {
             entry.getValue().close();
@@ -564,7 +569,9 @@ public class RocksDBState extends BaseState {
         // you need to iterate everything.
         ByteArray handleName = new ByteArray(keySpace);
         Preconditions.checkNotNull(cfHandles.get(handleName));
-        return new Iterator(rocksDB.newIterator(cfHandles.get(handleName)));
+        Iterator iterator = new Iterator(rocksDB.newIterator(cfHandles.get(handleName)));
+        iterators.add(iterator);
+        return iterator;
     }
 
     @Override

--- a/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
+++ b/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
@@ -205,7 +205,6 @@ public class RocksDBStateTest {
             assertEquals(count.toString(), new String(pair.getValue()));
             count++;
         }
-        iter.close();
         assertEquals(200, (int) count);
 
         //Write more data and backup
@@ -226,7 +225,6 @@ public class RocksDBStateTest {
             assertEquals(count.toString(), new String(pair.getValue()));
             count++;
         }
-        iter.close();
 
         //Check that all expected data exists
         assertEquals(250, (int) count);
@@ -371,7 +369,6 @@ public class RocksDBStateTest {
             assertEquals(count.toString(), new String(pair.getValue()));
             count++;
         }
-        iter.close();
         assertEquals(100, (int) count);
     }
 


### PR DESCRIPTION
In order to avoid iterators leaking, make sure RocksDBState keeps track of all iterators it hands out and closes them on `RocksDBState.close()`