### PR TITLE
Verify RocksDB state integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Southpaw accepts command line arguments and has a help option:
                              input record relations
     --restore              Restores the state from existing
                              backups.
+    --verify-state         Compares the state index to reverse index
+                             for each relational join and logs any
+                             errors
 
 *NOTE: Setting the `--restore` flag functions similar to setting `rocks.db.restore.mode: always` config option except that it can be used without dependencies on Kafka or opening RocksDB state. If the `--restore` flag is used with the `--build` flag and `rocks.db.restore.mode` is set to `always` or `when_needed`, a restore can be performed twice before fully starting up.*
 

--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -1015,6 +1015,11 @@ public class Southpaw {
         }
     }
 
+    /**
+     * Utility command to verify all indices and reverse indices in the State are in sync with each other. Keys that
+     * are not set properly in the index and reverse index are logged to error.
+     * <b>Note: this requires a full scan of each index dataset. This could be an expensive operation on larger datasets</b>
+     */
     protected void verifyState() {
         for(Map.Entry<String, BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>>> index: fkIndices.entrySet()) {
             logger.info("Verifying index state integrity: " + index.getValue().getIndexedTopic().getShortName());

--- a/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
+++ b/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
@@ -293,6 +293,11 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
         }
     }
 
+    /**
+     * Iterates through each entry in the reverse index and verifies the symmetric entries exist in the regular index
+     * and correctly point to the reverse index
+     * @return A string representation set of reverse index entry keys that are missing from the regular index.
+     */
     public Set<String> verifyIndexState() {
         System.out.println("Verifying reverse index: " + reverseIndexName + " against index: " + indexName);
         Set<String> missingKeys = new HashSet<>();
@@ -315,6 +320,11 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
         return missingKeys;
     }
 
+    /**
+     * Iterates through each entry in the regular index and verifies the symmetric entries exist in the reverse index
+     * and correctly point to the regular index
+     * @return A string representation set of regular index entry keys that are missing from the reverse index.
+     */
     public Set<String> verifyReverseIndexState() {
         System.out.println("Verifying index: " + indexName + " against reverse index: " + reverseIndexName);
         Set<String> missingKeys = new HashSet<>();


### PR DESCRIPTION
Adds a new CLI command `--verify-state` which can be used as a utility to ensure the RocksDB state index and reverse index for each relational join are in sync