### PR TITLE
Incrementally flush column families to ensure data integrity

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -407,6 +407,7 @@ public class Southpaw {
         }
         for(Map.Entry<Relation, ByteArraySet> entry: dePKsByType.entrySet()) {
             state.put(METADATA_KEYSPACE, createDePKEntryName(entry.getKey()).getBytes(), entry.getValue().serialize());
+            state.flush(METADATA_KEYSPACE);
         }
         for(Map.Entry<String, BaseTopic<BaseRecord, BaseRecord>> entry: inputTopics.entrySet()) {
             entry.getValue().commit();

--- a/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
+++ b/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
@@ -114,6 +114,8 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
         }
         pendingWrites.clear();
         pendingRIWrites.clear();
+        state.flush(indexName);
+        state.flush(reverseIndexName);
     }
 
     @Override


### PR DESCRIPTION
RocksDB flush changes introduced in #41 caused a regression where a case could exist where some data in the relations index and reverse index could go missing during a Southpaw commit which would cause records to fail to be associated with a denormalized record and go missing. This change reintroduces state flushes during index flushes to ensure data gets persisted prior to committing kafka offsets but still retains the major lift gained in #41 by avoiding flushing on each denormalized record created.