### PR TITLE
Ensure index and reverse index are idempotent

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -931,17 +931,14 @@ public class Southpaw {
         if(newRecord.value() != null) {
             newJoinKey = ByteArray.toByteArray(newRecord.value().get(relation.getJoinKey()));
         }
-        boolean addNewJoinKey = true;
         if (oldJoinKeys != null && oldJoinKeys.size() > 0) {
             for(ByteArray oldJoinKey: oldJoinKeys) {
                 if(!oldJoinKey.equals(newJoinKey)) {
                     joinIndex.remove(oldJoinKey, primaryKey);
-                } else {
-                    addNewJoinKey = false;
                 }
             }
         }
-        if (newJoinKey != null && addNewJoinKey) {
+        if (newJoinKey != null) {
             joinIndex.add(newJoinKey, primaryKey);
         }
     }

--- a/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
+++ b/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
@@ -204,12 +204,8 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
         ByteArraySet primaryKeys = getIndexEntry(foreignKey);
         if(primaryKeys != null) {
             state.delete(indexName, foreignKey.getBytes());
-            if(entryCache.containsKey(foreignKey)) {
-                entryCache.remove(foreignKey);
-            }
-            if(pendingWrites.containsKey(foreignKey)) {
-                pendingWrites.remove(foreignKey);
-            }
+            entryCache.remove(foreignKey);
+            pendingWrites.remove(foreignKey);
             for(ByteArray primaryKey: primaryKeys) {
                 removeRI(foreignKey, primaryKey);
             }
@@ -228,12 +224,8 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
             foreignKeys.remove(foreignKey);
             if(foreignKeys.size() == 0) {
                 state.delete(reverseIndexName, primaryKey.getBytes());
-                if(entryRICache.containsKey(primaryKey)) {
-                    entryRICache.remove(primaryKey);
-                }
-                if(pendingRIWrites.containsKey(primaryKey)) {
-                    pendingRIWrites.remove(primaryKey);
-                }
+                entryRICache.remove(primaryKey);
+                pendingRIWrites.remove(primaryKey);
             } else {
                 putRIToState(primaryKey, foreignKeys);
             }
@@ -249,9 +241,7 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
             if(primaryKeys.remove(primaryKey)) {
                 if(primaryKeys.size() == 0) {
                     state.delete(indexName, foreignKey.getBytes());
-                    if(entryCache.containsKey(foreignKey)) {
-                        entryCache.remove(foreignKey);
-                    }
+                    entryCache.remove(foreignKey);
                     pendingWrites.remove(foreignKey);
                 } else {
                     putToState(foreignKey, primaryKeys);

--- a/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
+++ b/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
@@ -68,8 +68,8 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
         if(pks == null) {
             pks = new ByteArraySet();
         }
+        addRI(foreignKey, primaryKey);
         if(pks.add(primaryKey)) {
-            addRI(foreignKey, primaryKey);
             putToState(foreignKey, pks);
         }
     }
@@ -245,6 +245,7 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
         Preconditions.checkNotNull(foreignKey);
         ByteArraySet primaryKeys = getIndexEntry(foreignKey);
         if(primaryKeys != null) {
+            removeRI(foreignKey, primaryKey);
             if(primaryKeys.remove(primaryKey)) {
                 if(primaryKeys.size() == 0) {
                     state.delete(indexName, foreignKey.getBytes());
@@ -255,7 +256,6 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
                 } else {
                     putToState(foreignKey, primaryKeys);
                 }
-                removeRI(foreignKey, primaryKey);
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
Fixes a bug where the join indices and reverse indices could get into an inconsistent state after an unclean shutdown.