### PR TITLE
Always attempt to remove reverse index references

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
+++ b/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
@@ -235,9 +235,9 @@ public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements
     @Override
     public boolean remove(ByteArray foreignKey, ByteArray primaryKey) {
         Preconditions.checkNotNull(foreignKey);
+        removeRI(foreignKey, primaryKey);
         ByteArraySet primaryKeys = getIndexEntry(foreignKey);
         if(primaryKeys != null) {
-            removeRI(foreignKey, primaryKey);
             if(primaryKeys.remove(primaryKey)) {
                 if(primaryKeys.size() == 0) {
                     state.delete(indexName, foreignKey.getBytes());


### PR DESCRIPTION
Fixes a bug where the reverse index couldn't remove a primary key reference if the primary key was already removed from the forward index.