### PR TITLE
Persist denormalized keys before writing records

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -310,6 +310,8 @@ public class Southpaw {
                             }
                             int size = dePrimaryKeys.size();
                             if(size > config.createRecordsTrigger) {
+                                state.put(METADATA_KEYSPACE, createDePKEntryName(root).getBytes(), dePrimaryKeys.serialize());
+                                state.flush(METADATA_KEYSPACE);
                                 createDenormalizedRecords(root, dePrimaryKeys);
                                 dePrimaryKeys.clear();
                             }

--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -105,7 +105,7 @@ public class Southpaw {
      * records) and join indices (points at the child records). The key is the index name. Multiple offsets
      * can be stored per key.
      */
-    protected final Map<String, BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>>> fkIndices = new HashMap<>();
+    protected final Map<String, BaseIndex<BaseRecord, BaseRecord, ByteArraySet>> fkIndices = new HashMap<>();
     /**
      * A map of all input topics needed by Southpaw. The key is the short name of the topic.
      */
@@ -268,7 +268,7 @@ public class Southpaw {
                         ConsumerRecord<BaseRecord, BaseRecord> newRecord = records.next();
                         ByteArray primaryKey = newRecord.key().toByteArray();
                         for (Relation root : relations) {
-                            Set<ByteArray> dePrimaryKeys = dePKsByType.get(root);
+                            ByteArraySet dePrimaryKeys = dePKsByType.get(root);
                             if (root.getEntity().equals(entity)) {
                                 // The top level relation is the relation of the input record
                                 dePrimaryKeys.add(primaryKey);
@@ -276,14 +276,14 @@ public class Southpaw {
                                 // Check the child relations instead
                                 AbstractMap.SimpleEntry<Relation, Relation> child = getRelation(root, entity);
                                 if (child != null && child.getValue() != null) {
-                                    BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> parentIndex =
+                                    BaseIndex<BaseRecord, BaseRecord, ByteArraySet> parentIndex =
                                             fkIndices.get(createParentIndexName(root, child.getKey(), child.getValue()));
                                     ByteArray newParentKey = null;
-                                    Set<ByteArray> oldParentKeys;
+                                    ByteArraySet oldParentKeys;
                                     if (newRecord.value() != null) {
                                         newParentKey = ByteArray.toByteArray(newRecord.value().get(child.getValue().getJoinKey()));
                                     }
-                                    BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> joinIndex =
+                                    BaseIndex<BaseRecord, BaseRecord, ByteArraySet> joinIndex =
                                             fkIndices.get(createJoinIndexName(child.getValue()));
                                     oldParentKeys = ((Reversible) joinIndex).getForeignKeys(primaryKey);
 
@@ -291,7 +291,7 @@ public class Southpaw {
                                     if (oldParentKeys != null) {
                                         for (ByteArray oldParentKey : oldParentKeys) {
                                             if (!ObjectUtils.equals(oldParentKey, newParentKey)) {
-                                                Set<ByteArray> primaryKeys = parentIndex.getIndexEntry(oldParentKey);
+                                                ByteArraySet primaryKeys = parentIndex.getIndexEntry(oldParentKey);
                                                 if (primaryKeys != null) {
                                                     dePrimaryKeys.addAll(primaryKeys);
                                                 }
@@ -299,7 +299,7 @@ public class Southpaw {
                                         }
                                     }
                                     if (newParentKey != null) {
-                                        Set<ByteArray> primaryKeys = parentIndex.getIndexEntry(newParentKey);
+                                        ByteArraySet primaryKeys = parentIndex.getIndexEntry(newParentKey);
                                         if (primaryKeys != null) {
                                             dePrimaryKeys.addAll(primaryKeys);
                                         }
@@ -402,7 +402,7 @@ public class Southpaw {
         for(Map.Entry<String, BaseTopic<byte[], DenormalizedRecord>> topic: outputTopics.entrySet()) {
             topic.getValue().flush();
         }
-        for(Map.Entry<String, BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>>> index: fkIndices.entrySet()) {
+        for(Map.Entry<String, BaseIndex<BaseRecord, BaseRecord, ByteArraySet>> index: fkIndices.entrySet()) {
             index.getValue().flush();
         }
         for(Map.Entry<Relation, ByteArraySet> entry: dePKsByType.entrySet()) {
@@ -467,8 +467,8 @@ public class Southpaw {
                 updateParentIndex(root, relation, child, rootPrimaryKey, newParentKey);
                 Map<ByteArray, DenormalizedRecord> records = new TreeMap<>();
                 if (newParentKey != null) {
-                    BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> joinIndex = fkIndices.get(createJoinIndexName(child));
-                    Set<ByteArray> childPKs = joinIndex.getIndexEntry(newParentKey);
+                    BaseIndex<BaseRecord, BaseRecord, ByteArraySet> joinIndex = fkIndices.get(createJoinIndexName(child));
+                    ByteArraySet childPKs = joinIndex.getIndexEntry(newParentKey);
                     if (childPKs != null) {
                         for (ByteArray childPK : childPKs) {
                             DenormalizedRecord deChildRecord = createDenormalizedRecord(root, child, rootPrimaryKey, childPK);
@@ -490,7 +490,7 @@ public class Southpaw {
      */
     protected void createDenormalizedRecords(
             Relation root,
-            Set<ByteArray> rootRecordPKs) {
+            ByteArraySet rootRecordPKs) {
         for(ByteArray dePrimaryKey: rootRecordPKs) {
             if(dePrimaryKey != null) {
                 BaseTopic<byte[], DenormalizedRecord> outputTopic = outputTopics.get(root.getDenormalizedName());
@@ -537,7 +537,7 @@ public class Southpaw {
      * @param indexedTopicName - The name of the indexed topic
      * @return A brand new, shiny index
      */
-    protected BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> createFkIndex(
+    protected BaseIndex<BaseRecord, BaseRecord, ByteArraySet> createFkIndex(
             String indexName,
             String indexedTopicName) {
         MultiIndex<BaseRecord, BaseRecord> index = new MultiIndex<>();
@@ -898,9 +898,9 @@ public class Southpaw {
 
         if(parent.getChildren() != null && rootPrimaryKey != null) {
             for(Relation child: parent.getChildren()) {
-                BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> parentIndex =
+                BaseIndex<BaseRecord, BaseRecord, ByteArraySet> parentIndex =
                         fkIndices.get(createParentIndexName(root, parent, child));
-                Set<ByteArray> oldForeignKeys = ((Reversible) parentIndex).getForeignKeys(rootPrimaryKey);
+                ByteArraySet oldForeignKeys = ((Reversible) parentIndex).getForeignKeys(rootPrimaryKey);
                 if(oldForeignKeys != null) {
                     for(ByteArray oldForeignKey: ImmutableSet.copyOf(oldForeignKeys)) {
                         parentIndex.remove(oldForeignKey, rootPrimaryKey);
@@ -925,8 +925,8 @@ public class Southpaw {
             ConsumerRecord<BaseRecord, BaseRecord> newRecord) {
         Preconditions.checkNotNull(relation.getJoinKey());
         Preconditions.checkNotNull(newRecord);
-        BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> joinIndex = fkIndices.get(createJoinIndexName(relation));
-        Set<ByteArray> oldJoinKeys = ((Reversible) joinIndex).getForeignKeys(primaryKey);
+        BaseIndex<BaseRecord, BaseRecord, ByteArraySet> joinIndex = fkIndices.get(createJoinIndexName(relation));
+        ByteArraySet oldJoinKeys = ((Reversible) joinIndex).getForeignKeys(primaryKey);
         ByteArray newJoinKey = null;
         if(newRecord.value() != null) {
             newJoinKey = ByteArray.toByteArray(newRecord.value().get(relation.getJoinKey()));
@@ -963,7 +963,7 @@ public class Southpaw {
         Preconditions.checkNotNull(child);
         Preconditions.checkNotNull(rootPrimaryKey);
 
-        BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> parentIndex =
+        BaseIndex<BaseRecord, BaseRecord, ByteArraySet> parentIndex =
                 fkIndices.get(createParentIndexName(root, parent, child));
         if (newParentKey != null) parentIndex.add(newParentKey, rootPrimaryKey);
     }
@@ -1018,7 +1018,7 @@ public class Southpaw {
      * <b>Note: this requires a full scan of each index dataset. This could be an expensive operation on larger datasets</b>
      */
     protected void verifyState() {
-        for(Map.Entry<String, BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>>> index: fkIndices.entrySet()) {
+        for(Map.Entry<String, BaseIndex<BaseRecord, BaseRecord, ByteArraySet>> index: fkIndices.entrySet()) {
             logger.info("Verifying index state integrity: " + index.getValue().getIndexedTopic().getShortName());
             Set<String> missingIndexKeys = ((MultiIndex)index.getValue()).verifyIndexState();
             if(missingIndexKeys.isEmpty()){

--- a/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
+++ b/src/main/java/com/jwplayer/southpaw/index/MultiIndex.java
@@ -31,7 +31,7 @@ import java.util.*;
  * @param <K> - The type of the key stored in the indexed topic
  * @param <V> - The type of the value stored in the indexed topic
  */
-public class MultiIndex<K, V> extends BaseIndex<K, V, Set<ByteArray>> implements Reversible {
+public class MultiIndex<K, V> extends BaseIndex<K, V, ByteArraySet> implements Reversible {
     /**
      * Size of the LRU cache for storing the index entries containing more than one key
      */

--- a/src/main/java/com/jwplayer/southpaw/index/Reversible.java
+++ b/src/main/java/com/jwplayer/southpaw/index/Reversible.java
@@ -16,6 +16,7 @@
 package com.jwplayer.southpaw.index;
 
 import com.jwplayer.southpaw.util.ByteArray;
+import com.jwplayer.southpaw.util.ByteArraySet;
 
 import java.util.Set;
 
@@ -28,5 +29,5 @@ public interface Reversible {
      * @param primaryKey - The primary key to lookup
      * @return The keys for the given primary key or null if no corresponding entry exists
      */
-    Set<ByteArray> getForeignKeys(ByteArray primaryKey);
+    ByteArraySet getForeignKeys(ByteArray primaryKey);
 }

--- a/src/test/java/com/jwplayer/southpaw/MockSouthpaw.java
+++ b/src/test/java/com/jwplayer/southpaw/MockSouthpaw.java
@@ -20,6 +20,7 @@ import com.jwplayer.southpaw.json.*;
 import com.jwplayer.southpaw.record.BaseRecord;
 import com.jwplayer.southpaw.topic.BaseTopic;
 import com.jwplayer.southpaw.util.ByteArray;
+import com.jwplayer.southpaw.util.ByteArraySet;
 
 import java.io.IOException;
 import java.net.URI;
@@ -41,7 +42,7 @@ public class MockSouthpaw extends Southpaw {
 
     public void createDenormalizedRecords(
             Relation root,
-            Set<ByteArray> rootRecordPKs) {
+            ByteArraySet rootRecordPKs) {
         super.createDenormalizedRecords(root, rootRecordPKs);
     }
 
@@ -61,7 +62,7 @@ public class MockSouthpaw extends Southpaw {
      * Accessor for the FK indices used by Southpaw
      * @return Southpaw's FK indices
      */
-    public Map<String, BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>>> getFkIndices() {
+    public Map<String, BaseIndex<BaseRecord, BaseRecord, ByteArraySet>> getFkIndices() {
         return fkIndices;
     }
 

--- a/src/test/java/com/jwplayer/southpaw/SouthpawTest.java
+++ b/src/test/java/com/jwplayer/southpaw/SouthpawTest.java
@@ -23,6 +23,7 @@ import com.jwplayer.southpaw.record.MapRecord;
 import com.jwplayer.southpaw.state.RocksDBState;
 import com.jwplayer.southpaw.topic.BaseTopic;
 import com.jwplayer.southpaw.util.ByteArray;
+import com.jwplayer.southpaw.util.ByteArraySet;
 import com.jwplayer.southpaw.util.FileHelper;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
@@ -99,7 +100,7 @@ public class SouthpawTest {
 
     @Test
     public void testFkIndices() {
-        Map<String, BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>>> indices = southpaw.getFkIndices();
+        Map<String, BaseIndex<BaseRecord, BaseRecord, ByteArraySet>> indices = southpaw.getFkIndices();
 
         assertEquals(10, indices.size());
         // Join Key Indices


### PR DESCRIPTION
- Makes consistent use of ByteArraySet over Set<ByteArray>
- Commits and flushes denormalized primary keys prior to writing out records