### PR TITLE
Upgrade to log4j2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Southpaw accepts command line arguments and has a help option:
     --build                Builds denormalized records using an
                              existing state.
     * --config             Path to the Southpaw config file
-    --debug                Sets logging to DEBUG.
     --delete-backup        Deletes existing backups specified in
                              the config file. BE VERY CAREFUL
                              WITH THIS!!!
@@ -147,7 +146,6 @@ The config is broken up into multiple sections:
 
 ### Generic Config
 
-* log.level - The level to log at (e.g. INFO or DEBUG). In the future should just be replaced with a properties file.
 * backup.time.s - The amount of time in seconds between backups
 * commit.time.s - The amount of time in seconds between full state commits
 * create.records.trigger - Number of denormalized record create actions to queue before creating denormalized records. Only queues creation of records when lagging. 
@@ -202,8 +200,6 @@ Similar to the state, Southpaw is built around Kafka for the log store. The topi
 * value.serde.class - The full name of the serde class for the record value
 
 ### Example
-
-    log.level: "INFO"
 
     backup.time.s: 600
     commit.time.s: 120
@@ -391,6 +387,10 @@ Southpaw exposes basic metrics about its operation and performance through JMX u
 * time.since.last.backup (Gauge) - The time (ms) since the last backup. Useful since backups.created can be a very sparse metric. Note that this will only start measuring when Southpaw starts. It doesn't measure since any previous instances of Southpaw.
 * topic.lag (Gauge) - Snapshots of the overall lag (end offset - current offset) for the input topics
 * topic.lag.[ENTITY_NAME] (Gauge) - Similar to topic.lag, but broken down by the specific normalized entity
+
+## Logging
+
+Southpaw makes use of [log4j2](https://logging.apache.org/log4j/2.x/) for logging. Refer to log4j2 documentation for how to easily configure logging to fit your needs.
 
 ## Known Issues
 

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -1,5 +1,3 @@
-log.level: "INFO"
-
 backup.time.s: 1800
 backup.on.shutdown: true
 commit.time.s: 0

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,19 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -127,6 +137,12 @@
             <artifactId>kafka_2.12</artifactId>
             <version>1.0.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -41,8 +41,9 @@ import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.time.StopWatch;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
@@ -86,7 +87,7 @@ public class Southpaw {
     /**
      * Le Logger
      */
-    private static final Logger logger = Logger.getLogger(Southpaw.class);
+    private static final Logger logger = LogManager.getLogger(Southpaw.class);
     /**
      * Used for doing object <-> JSON mappings
      */
@@ -142,9 +143,6 @@ public class Southpaw {
      * Base Southpaw config
      */
     protected static class Config {
-        public static final String BACKUP_ON_SHUTDOWN_CONFIG = "backup.on.shutdown";
-        public static final boolean BACKUP_ON_SHUTDOWN_DEFAULT = false;
-        public static final String BACKUP_ON_SHUTDOWN_DOC = "Instructs Southpaw to backup on shutdown (or not)";
         public static final String BACKUP_TIME_S_CONFIG = "backup.time.s";
         public static final int BACKUP_TIME_S_DEFAULT = 1800;
         public static final String BACKUP_TIME_S_DOC = "Time interval (roughly) between backups";
@@ -156,28 +154,21 @@ public class Southpaw {
         public static final String CREATE_RECORDS_TRIGGER_DOC =
                 "Config for when to create denormalized records once the number of records to create has exceeded " +
                         "a certain amount";
-        public static final String LOG_LEVEL_CONFIG = "log.level";
-        public static final String LOG_LEVEL_DEFAULT = "INFO";
-        public static final String LOG_LEVEL_DOC = "Log level config for log4j";
         public static final String TOPIC_LAG_TRIGGER_CONFIG = "topic.lag.trigger";
         public static final String TOPIC_LAG_TRIGGER_DEFAULT = "1000";
         public static final String TOPIC_LAG_TRIGGER_DOC =
                 "Config for when to switch from one topic to the next (or to stop processing a topic entirely), " +
                         "when lag drops below this value.";
 
-        public boolean backupOnShutdown;
         public int backupTimeS;
         public int commitTimeS;
         public int createRecordsTrigger;
-        public String logLevel;
         public int topicLagTrigger;
 
         public Config(Map<String, Object> rawConfig) throws ClassNotFoundException {
-            this.backupOnShutdown = (boolean) rawConfig.getOrDefault(BACKUP_ON_SHUTDOWN_CONFIG, BACKUP_ON_SHUTDOWN_DEFAULT);
             this.backupTimeS = (int) rawConfig.getOrDefault(BACKUP_TIME_S_CONFIG, BACKUP_TIME_S_DEFAULT);
             this.commitTimeS = (int) rawConfig.getOrDefault(COMMIT_TIME_S_CONFIG, COMMIT_TIME_S_DEFAULT);
             this.createRecordsTrigger = (int) rawConfig.getOrDefault(CREATE_RECORDS_TRIGGER_CONFIG, CREATE_RECORDS_TRIGGER_DEFAULT);
-            this.logLevel = rawConfig.getOrDefault(LOG_LEVEL_CONFIG, LOG_LEVEL_DEFAULT).toString();
             this.topicLagTrigger = (int) rawConfig.getOrDefault(TOPIC_LAG_TRIGGER_CONFIG, TOPIC_LAG_TRIGGER_DEFAULT);
         }
     }
@@ -206,7 +197,6 @@ public class Southpaw {
 
         this.rawConfig = Preconditions.checkNotNull(rawConfig);
         this.config = new Config(rawConfig);
-        logger.setLevel(Level.toLevel(config.logLevel, Level.INFO));
         this.relations = Preconditions.checkNotNull(relations);
         this.state = new RocksDBState(rawConfig);
         this.state.open();
@@ -790,7 +780,6 @@ public class Southpaw {
                 accepts(DELETE_BACKUP, "Deletes existing backups specified in the config file. BE VERY CAREFUL WITH THIS!!!");
                 accepts(DELETE_STATE, "Deletes the existing state specified in the config file. BE VERY CAREFUL WITH THIS!!!");
                 accepts(RESTORE, "Restores the state from existing backups.");
-                accepts(DEBUG, "Sets logging to DEBUG.").withOptionalArg();
                 accepts(HELP, "Since you are seeing this, you probably know what this is for. :)").forHelp();
                 accepts(VERIFY_STATE, "Verifies that the Southpaw state indices and reverse indices are in sync");
             }
@@ -801,7 +790,6 @@ public class Southpaw {
             parser.printHelpOn(System.out);
             System.exit(0);
         }
-        if(options.has(DEBUG)) Logger.getRootLogger().setLevel(Level.DEBUG);
 
         Yaml yaml = new Yaml();
         Map<String, Object> config = yaml.load(FileHelper.getInputStream(new URI(options.valueOf(CONFIG).toString())));

--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -23,7 +23,8 @@ import com.jwplayer.southpaw.util.FileHelper;
 import com.jwplayer.southpaw.util.S3Helper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.codec.binary.Hex;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.rocksdb.*;
 
 import java.io.File;
@@ -38,7 +39,7 @@ import java.util.concurrent.ExecutionException;
  * Rocks DB implementation for the state
  */
 public class RocksDBState extends BaseState {
-    private static final Logger logger = Logger.getLogger(RocksDBState.class);
+    private static final Logger logger = LogManager.getLogger(RocksDBState.class);
     /**
      * URI to backup RocksDB to
      */

--- a/src/main/java/com/jwplayer/southpaw/topic/KafkaTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/KafkaTopic.java
@@ -27,7 +27,8 @@ import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.*;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -46,7 +47,7 @@ public class KafkaTopic<K, V> extends BaseTopic<K, V> {
     /**
      * Le Logger
      */
-    private static final Logger logger = Logger.getLogger(KafkaTopic.class);
+    private static final Logger logger = LogManager.getLogger(KafkaTopic.class);
 
     /**
      * This allows us to capture the record and update our state when next() is called.

--- a/src/main/java/com/jwplayer/southpaw/util/S3Helper.java
+++ b/src/main/java/com/jwplayer/southpaw/util/S3Helper.java
@@ -32,7 +32,8 @@ import com.codahale.metrics.Timer;
 import com.codahale.metrics.jmx.JmxReporter;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.net.URI;
@@ -105,7 +106,7 @@ public class S3Helper {
      * AWS secret key config
      */
     public static final String SECRET_KEY_CONFIG = "aws.s3.secret.key";
-    private static final Logger logger = Logger.getLogger(S3Helper.class);
+    private static final Logger logger = LogManager.getLogger(S3Helper.class);
 
     private ExecutorService executor;
     protected boolean exceptionOnError;

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=INFO, console
-
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-30c{2} %x - %m%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,12 @@
+status = error
+name = DefaultSouthpawConfig
+
+appenders = console
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %-30c{2} %x - %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -5,7 +5,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %-30c{2} %x - %m%n
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %-30c{2} - %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = stdout

--- a/test-resources/config.sample.yaml
+++ b/test-resources/config.sample.yaml
@@ -1,5 +1,3 @@
-log.level: "DEBUG"
-
 backup.time.s: 600
 backup.on.shutdown: false
 commit.time.s: 60


### PR DESCRIPTION
- Upgrades southpaw logging from log4j 1.2 to log4j 2.x in order to solve [CVE-2019-17571](https://github.com/advisories/GHSA-2qrg-x229-3v8q)
- Removes southpaw config option for setting logging level in favor of enforcing all logging configurations are done through standard log4j2 configuration mechanisms
- Removes southpaw config references to `BACKUP_ON_SHUTDOWN` since the functionality itself had already been removed in https://github.com/jwplayer/southpaw/pull/32