### PR TITLE
Add support for building against Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ relations/
 # IntelliJ
 .idea/
 *.iml
+
+# jenv
+*.java-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ cache:
     - $HOME/.m2/repository
 jdk:
   - openjdk8
+  - openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <version.cobertura.plugin>2.7</version.cobertura.plugin>
         <version.jsonschema2pojo.plugin>1.0.0</version.jsonschema2pojo.plugin>
         <version.shade.plugin>2.3</version.shade.plugin>
+        <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
 
 
     </properties>
@@ -192,6 +193,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.surefire.plugin}</version>
                 <configuration>
                     <argLine>-Xmx1024m</argLine>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <version.cobertura.plugin>2.7</version.cobertura.plugin>
         <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
         <version.jsonschema2pojo.plugin>1.0.0</version.jsonschema2pojo.plugin>
-        <version.shade.plugin>2.3</version.shade.plugin>
+        <version.shade.plugin>3.2.4</version.shade.plugin>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 
         <!-- Plugins -->
         <version.cobertura.plugin>2.7</version.cobertura.plugin>
+        <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
         <version.jsonschema2pojo.plugin>1.0.0</version.jsonschema2pojo.plugin>
         <version.shade.plugin>2.3</version.shade.plugin>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
@@ -177,6 +178,26 @@
         <testSourceDirectory>src/test/java</testSourceDirectory>
         <finalName>southpaw</finalName>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${version.enforcer.plugin}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.6.3</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,124 +23,151 @@
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <jackson.version>2.11.1</jackson.version>
-        <guava.version>29.0-jre</guava.version>
+
+        <version.amazonaws>1.11.292</version.amazonaws>
+        <version.apache.commons>4.1</version.apache.commons>
+        <version.avro>1.8.2</version.avro>
+        <version.commons.io>2.6</version.commons.io>
+        <version.commons.lang>2.6</version.commons.lang>
+        <version.confluent>4.0.0</version.confluent>
+        <version.dropwizard>4.0.2</version.dropwizard>
+        <version.guava>29.0-jre</version.guava>
+        <version.jackson>2.11.1</version.jackson>
+        <version.jopt.simple>4.9</version.jopt.simple>
+        <version.kafka>1.0.0</version.kafka>
+        <version.kafka>2.0.0</version.kafka>
+        <version.logback>1.2.3</version.logback>
+        <version.rocksdb>5.17.2</version.rocksdb>
+        <version.snakeyaml>1.20</version.snakeyaml>
+
+        <!-- Testing -->
+        <version.curator>2.12.0</version.curator>
+        <version.junit>4.11</version.junit>
+        <version.mockito>2.25.1</version.mockito>
+        <version.s3mock>0.2.5</version.s3mock>
+
+        <!-- Plugins -->
+        <version.cobertura.plugin>2.7</version.cobertura.plugin>
+        <version.jsonschema2pojo.plugin>1.0.0</version.jsonschema2pojo.plugin>
+        <version.shade.plugin>2.3</version.shade.plugin>
+
+
     </properties>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>${version.logback}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
+            <version>${version.guava}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
+            <version>${version.apache.commons}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>${version.commons.io}</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <version>${version.commons.lang}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>1.0.0</version>
+            <version>${version.kafka}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>1.0.0</version>
+            <version>${version.kafka}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.8.2</version>
+            <version>${version.avro}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-streams-avro-serde</artifactId>
-            <version>4.0.0</version>
+            <version>${version.confluent}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-json-serializer</artifactId>
-            <version>4.0.0</version>
+            <version>${version.confluent}</version>
         </dependency>
         <dependency>
             <groupId>org.rocksdb</groupId>
             <artifactId>rocksdbjni</artifactId>
-            <version>5.17.2</version>
+            <version>${version.rocksdb}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${version.jackson}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.11.292</version>
+            <version>${version.amazonaws}</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.20</version>
+            <version>${version.snakeyaml}</version>
         </dependency>
         <dependency>
             <groupId>net.sf.jopt-simple</groupId>
             <artifactId>jopt-simple</artifactId>
-            <version>4.9</version>
+            <version>${version.jopt.simple}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.0.2</version>
+            <version>${version.dropwizard}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jmx</artifactId>
-            <version>4.0.2</version>
+            <version>${version.dropwizard}</version>
         </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>1.0.0</version>
+            <version>${version.kafka}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>2.12.0</version>
+            <version>${version.curator}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>
             <artifactId>s3mock_2.12</artifactId>
-            <version>0.2.5</version>
+            <version>${version.s3mock}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.25.1</version>
+            <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -152,7 +179,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>${version.shade.plugin}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -172,7 +199,7 @@
             <plugin>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>${version.jsonschema2pojo.plugin}</version>
                 <configuration>
                     <sourceDirectory>${basedir}/src/main/resources/southpaw/schema</sourceDirectory>
                     <targetPackage>com.jwplayer.southpaw.json</targetPackage>
@@ -191,7 +218,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>${version.cobertura.plugin}</version>
                 <configuration>
                     <check>
                     </check>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,12 @@
             <artifactId>metrics-jmx</artifactId>
             <version>${version.dropwizard}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${version.xml.bind}</version>
+        </dependency>
+        
         <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>
@@ -173,11 +179,6 @@
             <artifactId>mockito-core</artifactId>
             <version>${version.mockito}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${version.xml.bind}</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,10 @@
         </repository>
     </repositories>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
+        <release>8</release>
 
         <version.amazonaws>1.11.292</version.amazonaws>
         <version.apache.commons>4.1</version.apache.commons>
@@ -39,6 +41,7 @@
         <version.logback>1.2.3</version.logback>
         <version.rocksdb>5.17.2</version.rocksdb>
         <version.snakeyaml>1.20</version.snakeyaml>
+        <version.xml.bind>2.3.1</version.xml.bind>
 
         <!-- Testing -->
         <version.curator>2.12.0</version.curator>
@@ -46,14 +49,15 @@
         <version.mockito>2.25.1</version.mockito>
         <version.s3mock>0.2.5</version.s3mock>
 
+        <modules.argline />
+
         <!-- Plugins -->
         <version.cobertura.plugin>2.7</version.cobertura.plugin>
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
         <version.jsonschema2pojo.plugin>1.0.0</version.jsonschema2pojo.plugin>
         <version.shade.plugin>3.2.4</version.shade.plugin>
         <version.surefire.plugin>3.0.0-M5</version.surefire.plugin>
-
-
     </properties>
     <dependencies>
         <dependency>
@@ -172,12 +176,27 @@
             <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${version.xml.bind}</version>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <testSourceDirectory>src/test/java</testSourceDirectory>
         <finalName>southpaw</finalName>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${version.compiler.plugin}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -216,7 +235,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.surefire.plugin}</version>
                 <configuration>
-                    <argLine>-Xmx1024m</argLine>
+                    <argLine>-Djava.awt.headless=true ${modules.argline}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -257,4 +276,18 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <properties>
+                <modules.argline>--illegal-access=permit</modules.argline>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <release>11</release>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
         <version.jackson>2.11.1</version.jackson>
         <version.jopt.simple>4.9</version.jopt.simple>
         <version.kafka>1.0.0</version.kafka>
-        <version.kafka>2.0.0</version.kafka>
         <version.logback>1.2.3</version.logback>
         <version.rocksdb>5.17.2</version.rocksdb>
         <version.snakeyaml>1.20</version.snakeyaml>
@@ -52,7 +51,6 @@
         <modules.argline />
 
         <!-- Plugins -->
-        <version.cobertura.plugin>2.7</version.cobertura.plugin>
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.enforcer.plugin>3.0.0-M3</version.enforcer.plugin>
         <version.jsonschema2pojo.plugin>1.0.0</version.jsonschema2pojo.plugin>
@@ -253,23 +251,6 @@
                     <execution>
                         <goals>
                             <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>${version.cobertura.plugin}</version>
-                <configuration>
-                    <check>
-                    </check>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>clean</goal>
-                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
- Adds a new maven profile that is automatically activated if current JAVA_HOME jdk is java 11
- Adds openjdk11 build to travis
- Moves all dependency versions to property variables
- Updates the maven-shade-plugin dependency
- Adds the maven-enforcer-plugin to set minimum maven version
 - Removed cobertura plugin. Wasn't configured to run previously. It also receives a class not found issue on java 11