### PR TITLE
Reuse a RocksDB BackupEngine object

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -723,6 +723,7 @@ public class Southpaw {
     public static void deleteBackups(Map<String, Object> config) {
         BaseState state =  new RocksDBState(config);
         state.deleteBackups();
+        state.close();
     }
 
     /**

--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -721,9 +721,15 @@ public class Southpaw {
      * require creating a new instance to continue processing.
      */
     public static void deleteBackups(Map<String, Object> config) {
-        BaseState state =  new RocksDBState(config);
-        state.deleteBackups();
-        state.close();
+        BaseState state = null;
+        try {
+            state =  new RocksDBState(config);
+            state.deleteBackups();
+        } finally {
+            if (state != null) {
+                state.close();
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -252,6 +252,7 @@ public class RocksDBState extends BaseState {
     public void backup() {
         logger.info("Backing up RocksDB state");
         try {
+            openBackupEngine();
             backupEngine.createNewBackup(rocksDB, true);
             backupEngine.purgeOldBackups(backupsToKeep);
         } catch(RocksDBException ex) {
@@ -304,8 +305,8 @@ public class RocksDBState extends BaseState {
     }
 
     private void closeBackupEngine() {
-        logger.info("Closing RocksDB backup engine");
         if (backupEngine != null) {
+            logger.info("Closing RocksDB backup engine");
             backupOptions.close();
             backupEngine.close();
         }
@@ -453,8 +454,6 @@ public class RocksDBState extends BaseState {
             for(ColumnFamilyHandle handle: handles) {
                 cfHandles.put(new ByteArray(handle.getName()), handle);
             }
-
-            openBackupEngine();
         } catch(Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -706,3 +706,4 @@ public class RocksDBState extends BaseState {
         }
     }
 }
+

--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -274,8 +274,8 @@ public class RocksDBState extends BaseState {
         if(!isOpen()) {
             return;
         }
-        super.close();
         logger.info("Closing RocksDB state");
+        super.close();
 
         for (Iterator iterator : iterators) {
             iterator.close();
@@ -302,6 +302,7 @@ public class RocksDBState extends BaseState {
             s3Helper.close();
             s3Helper = null;
         }
+        logger.info("RocksDB state closed");
     }
 
     private void closeBackupEngine() {
@@ -309,6 +310,7 @@ public class RocksDBState extends BaseState {
             logger.info("Closing RocksDB backup engine");
             backupOptions.close();
             backupEngine.close();
+            logger.info("RocksDB backup engine closed");
         }
 
         backupOptions = null;
@@ -344,7 +346,7 @@ public class RocksDBState extends BaseState {
             File file = new File(backupPath);
             if (!file.exists()) {
                 boolean created = file.mkdir();
-                logger.info("Created directory: " + created);
+                logger.info("Created RocksDB backup directory: " + created);
             }
             backupPath = file.getPath();
 
@@ -358,6 +360,7 @@ public class RocksDBState extends BaseState {
         if(isOpen()){
             throw new RuntimeException("RocksDB is already open!");
         }
+        logger.info("Opening RocksDB state");
         try {
             // Create the backing DB
             sstFileManager = new SstFileManager(Env.getDefault());
@@ -458,6 +461,7 @@ public class RocksDBState extends BaseState {
             throw new RuntimeException(ex);
         }
         super.open();
+        logger.info("Finished opening RocksDB state");
     }
 
     private void openBackupEngine() throws RocksDBException{

--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -19,16 +19,13 @@ import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
 import com.jwplayer.southpaw.metric.Metrics;
 import com.jwplayer.southpaw.util.ByteArray;
-import com.jwplayer.southpaw.util.FileHelper;
 import com.jwplayer.southpaw.util.S3Helper;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.rocksdb.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
@@ -129,9 +126,13 @@ public class RocksDBState extends BaseState {
     }
 
     /**
-     * Backup URI
+     * Backup URI where a backup will end up
      */
     protected URI backupURI;
+    /**
+     * Backup Path. local path where a backup will write out to
+     */
+    protected String backupPath;
     /**
      * Auto rollback to previous backups on restoration failure
      */
@@ -202,6 +203,14 @@ public class RocksDBState extends BaseState {
      */
     protected Options rocksDBOptions;
     /**
+     * RocksDB backup engine
+     */
+    protected BackupEngine backupEngine;
+    /**
+     * Rocks DB backup engine options
+     */
+    protected BackupableDBOptions backupOptions;
+    /**
      * Rocks DB Flush options
      */
     protected FlushOptions flushOptions;
@@ -243,17 +252,10 @@ public class RocksDBState extends BaseState {
     public void backup() {
         logger.info("Backing up RocksDB state");
         try {
-            switch(backupURI.getScheme().toLowerCase()) {
-                case FileHelper.SCHEME:
-                    backup(backupURI.getPath());
-                    break;
-                case S3Helper.SCHEME:
-                    String localBackupPath = getLocalBackupPath(uri);
-                    backup(localBackupPath);
-                    s3Helper.syncToS3(new URI(localBackupPath), backupURI);
-                    break;
-                default:
-                    throw new RuntimeException("Unsupported schema: " + backupURI.getScheme());
+            backup(backupPath);
+
+            if(s3Helper != null) {
+                s3Helper.syncToS3(new URI(backupPath), backupURI);
             }
         } catch(InterruptedException | ExecutionException | URISyntaxException | RocksDBException ex) {
             throw new RuntimeException(ex);
@@ -266,16 +268,8 @@ public class RocksDBState extends BaseState {
      * @param backupPath - The local backup path
      */
     protected void backup(String backupPath) throws RocksDBException {
-        File file = new File(backupPath);
-        if(!file.exists()) file.mkdir();
-        logger.info("Opening RocksDB backup engine");
-        try (final BackupableDBOptions backupOptions = new BackupableDBOptions(backupPath)
-                .setShareTableFiles(true)
-                .setMaxBackgroundOperations(parallelism);
-            final BackupEngine backupEngine = BackupEngine.open(Env.getDefault(), backupOptions)) {
-            backupEngine.createNewBackup(rocksDB, true);
-            backupEngine.purgeOldBackups(backupsToKeep);
-        }
+        backupEngine.createNewBackup(rocksDB, true);
+        backupEngine.purgeOldBackups(backupsToKeep);
     }
 
     @Override
@@ -284,6 +278,7 @@ public class RocksDBState extends BaseState {
             return;
         }
         super.close();
+        logger.info("Closing RocksDB state");
 
         for (Iterator iterator : iterators) {
             iterator.close();
@@ -304,9 +299,21 @@ public class RocksDBState extends BaseState {
         writeOptions = null;
         rocksDB = null;
 
+        closeBackupEngine();
+
         if (s3Helper != null) {
             s3Helper.close();
+            s3Helper = null;
         }
+    }
+
+    private void closeBackupEngine() {
+        logger.info("Closing RocksDB backup engine");
+        backupOptions.close();
+        backupEngine.close();
+
+        backupOptions = null;
+        backupEngine = null;
     }
 
     @Override
@@ -330,7 +337,18 @@ public class RocksDBState extends BaseState {
 
             if(backupURI.getScheme().toLowerCase().equals(S3Helper.SCHEME)) {
                 s3Helper = new S3Helper(config);
+                backupPath = getLocalBackupPath(backupURI);
+            } else {
+                backupPath = backupURI.getPath();
             }
+
+            File file = new File(backupPath);
+            if (!file.exists()) {
+                boolean created = file.mkdir();
+                logger.info("Created directory: " + created);
+            }
+            backupPath = file.getPath();
+
         } catch(Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -437,10 +455,22 @@ public class RocksDBState extends BaseState {
             for(ColumnFamilyHandle handle: handles) {
                 cfHandles.put(new ByteArray(handle.getName()), handle);
             }
+
+            openBackupEngine();
         } catch(Exception ex) {
             throw new RuntimeException(ex);
         }
         super.open();
+    }
+
+    private void openBackupEngine() throws RocksDBException{
+        if (backupEngine == null) {
+            logger.info("Opening RocksDB backup engine");
+            backupOptions = new BackupableDBOptions(backupPath)
+                    .setShareTableFiles(true)
+                    .setMaxBackgroundOperations(parallelism);
+            backupEngine = BackupEngine.open(Env.getDefault(), backupOptions);
+        }
     }
 
     @Override
@@ -498,22 +528,17 @@ public class RocksDBState extends BaseState {
     public void deleteBackups() {
         logger.info("Deleting RocksDB state backups");
         try {
-            File file;
-            switch(backupURI.getScheme().toLowerCase()) {
-                case FileHelper.SCHEME:
-                    file = new File(backupURI);
-                    FileUtils.deleteDirectory(file);
-                    break;
-                case S3Helper.SCHEME:
-                    String localBackupPath = getLocalBackupPath(uri);
-                    file = new File(localBackupPath);
-                    FileUtils.deleteDirectory(file);
-                    s3Helper.deleteKeys(backupURI);
-                    break;
-                default:
-                    throw new RuntimeException("Unsupported schema: " + backupURI.getScheme());
+            openBackupEngine();
+            final List<BackupInfo> backupInfoList = backupEngine.getBackupInfo();
+
+            for (BackupInfo backupInfo : backupInfoList) {
+                backupEngine.deleteBackup(backupInfo.backupId());
             }
-        } catch(IOException | InterruptedException | ExecutionException ex) {
+
+            if(s3Helper != null){
+                s3Helper.deleteKeys(backupURI);
+            }
+        } catch(RocksDBException | InterruptedException | ExecutionException ex) {
             throw new RuntimeException(ex);
         }
         metrics.backupsDeleted.mark();
@@ -618,20 +643,11 @@ public class RocksDBState extends BaseState {
         logger.info("Restoring RocksDB state from backups");
         try(Timer.Context context = metrics.backupsRestored.time()) {
             try {
-                switch (backupURI.getScheme().toLowerCase()) {
-                    case FileHelper.SCHEME:
-                        restore(uri, backupURI.getPath());
-                        break;
-                    case S3Helper.SCHEME:
-                        String localBackupPath = getLocalBackupPath(uri);
-                        File file = new File(localBackupPath);
-                        if (!file.exists()) file.mkdir();
-                        s3Helper.syncFromS3(new URI(localBackupPath), backupURI);
-                        restore(uri, localBackupPath);
-                        break;
-                    default:
-                        throw new RuntimeException("Unsupported schema: " + backupURI.getScheme());
+                if (s3Helper != null) {
+                    s3Helper.syncFromS3(new URI(backupPath), backupURI);
                 }
+                openBackupEngine();
+                restore(uri, backupPath);
             } catch (InterruptedException | ExecutionException | RocksDBException | URISyntaxException ex) {
                 throw new RuntimeException(ex);
             }
@@ -648,11 +664,7 @@ public class RocksDBState extends BaseState {
     protected void restore(URI dbUri, String backupPath) throws RocksDBException {
         File path = new File(backupPath);
         if(path.exists()) {
-            try (final BackupableDBOptions backupOptions = new BackupableDBOptions(backupPath)
-                    .setShareTableFiles(true)
-                    .setMaxBackgroundOperations(parallelism);
-                 final RestoreOptions restoreOptions = new RestoreOptions(false);
-                 final BackupEngine backupEngine = BackupEngine.open(Env.getDefault(), backupOptions)) {
+            try (final RestoreOptions restoreOptions = new RestoreOptions(false)) {
 
                 final List<BackupInfo> backupInfo = backupEngine.getBackupInfo();
 

--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -305,8 +305,10 @@ public class RocksDBState extends BaseState {
 
     private void closeBackupEngine() {
         logger.info("Closing RocksDB backup engine");
-        backupOptions.close();
-        backupEngine.close();
+        if (backupEngine != null) {
+            backupOptions.close();
+            backupEngine.close();
+        }
 
         backupOptions = null;
         backupEngine = null;


### PR DESCRIPTION
RocksDB [warns](https://github.com/facebook/rocksdb/wiki/How-to-backup-RocksDB%3F#backup-performance) against the overhead of initializing the BackupEngine. This appears it could be where we are seeing extensive time for the backup itself to complete before kicking off the background thread's S3 upload of the backup.

- Lazy opens rocksDB BackupEngine once upon first use as opposed to previously opening a new one every backup/restore/deletion of state.