### PR TITLE
replace newInstance with getDeclaredConstructor

### DIFF
--- a/src/test/java/com/jwplayer/southpaw/MockSouthpaw.java
+++ b/src/test/java/com/jwplayer/southpaw/MockSouthpaw.java
@@ -22,6 +22,7 @@ import com.jwplayer.southpaw.topic.BaseTopic;
 import com.jwplayer.southpaw.util.ByteArray;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.AbstractMap;
@@ -35,7 +36,7 @@ import java.util.Set;
  */
 public class MockSouthpaw extends Southpaw {
     public MockSouthpaw(Map<String, Object> config, List<URI> uris)
-            throws ClassNotFoundException, IllegalAccessException, InstantiationException, IOException, URISyntaxException {
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException, IOException, URISyntaxException, NoSuchMethodException, InvocationTargetException {
         super(config, uris);
     }
 


### PR DESCRIPTION
starting with Java 9 [newInstance is marked as deprecated](https://docs.oracle.com/javase/9/docs/api/java/lang/Class.html#newInstance--)

```
The call clazz.newInstance()
 
can be replaced by clazz.getDeclaredConstructor().newInstance()
```