### PR TITLE
adds jcl slf4j bridge required for logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <version.kafka>1.0.0</version.kafka>
         <version.logback>1.2.3</version.logback>
         <version.rocksdb>5.17.2</version.rocksdb>
+        <version.slf4j>1.7.25</version.slf4j>
         <version.snakeyaml>1.20</version.snakeyaml>
         <version.xml.bind>2.3.1</version.xml.bind>
 
@@ -62,6 +63,12 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${version.logback}</version>
+        </dependency>
+        <!-- required to bridge amazons use of java common logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${version.slf4j}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
since amazon's s3 lib depends on `java common logging` the current version doesn't respect logback's appender format

adding this slf4j bridge dependency allows the logback logging configuration to take control over JCL logging
