### PR TITLE
Transactional handling for Debezium PG CDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ Similar to the state, Southpaw is built around Kafka for the log store. The topi
 
 * jackson.serde.class - The full class name of the deserialized object created by the JacksonSerde class
 * key.serde.class - The full name of the serde class for the record key
-* poll.timeout - The Kafka consumer poll() timeout in milliseconds
 * topic.class - The full class name of the class used by the topic
 * topic.name - The name of the topic (not the entity name for this topic!)
 * value.serde.class - The full name of the serde class for the record value
@@ -223,7 +222,6 @@ Similar to the state, Southpaw is built around Kafka for the log store. The topi
         client.id: "southpaw"
         enable.auto.commit: false
         key.serde.class: "com.jwplayer.southpaw.serde.AvroSerde"
-        poll.timeout: 100
         schema.registry.url: "http://my-schema-registry:8081"
         topic.class: "com.jwplayer.southpaw.topic.KafkaTopic"
         value.serde.class: "com.jwplayer.southpaw.serde.AvroSerde"

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -32,7 +32,6 @@ topics:
     group.id: "southpaw"
     enable.auto.commit: false
     key.serde.class: "com.jwplayer.southpaw.serde.AvroSerde"
-    poll.timeout: 100
     schema.registry.url: "http://schema_registry_url:80"
     topic.class: "com.jwplayer.southpaw.topic.KafkaTopic"
     value.serde.class: "com.jwplayer.southpaw.serde.AvroSerde"

--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -23,6 +23,8 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -152,6 +154,13 @@ public class Southpaw {
      */
     protected BaseState state;
 
+    protected boolean topicsPrefixed;
+    private static final String TRANSACTIONS = "transactions";
+
+    protected String currentTxn;
+    protected boolean seenTxnEnd;
+    protected boolean transactional;
+
     /**
      * Base Southpaw config
      */
@@ -228,6 +237,13 @@ public class Southpaw {
             this.outputTopics.put(root.getDenormalizedName(), createOutputTopic(root.getDenormalizedName()));
             this.metrics.registerOutputTopic(root.getDenormalizedName());
         }
+        try {
+            this.inputTopics.put(TRANSACTIONS, createTopic(TRANSACTIONS));
+            transactional = true;
+            this.topicsPrefixed = (Boolean) rawConfig.getOrDefault("topics.prefixed", true);
+        } catch (NullPointerException e) {
+            //transactions not defined
+        }
         for(Map.Entry<String, BaseTopic<BaseRecord, BaseRecord>> entry: this.inputTopics.entrySet()) {
             this.metrics.registerInputTopic(entry.getKey());
         }
@@ -238,6 +254,13 @@ public class Southpaw {
             byte[] bytes = state.get(METADATA_KEYSPACE, createDePKEntryName(root).getBytes());
             dePKsByType.put(root, ByteArraySet.deserialize(bytes));
         }
+    }
+
+    private static class RecordHolder {
+        boolean txnTopic;
+        BaseTopic<BaseRecord, BaseRecord> inputTopic;
+        ConsumerRecordIterator<BaseRecord, BaseRecord> records;
+        String entity;
     }
 
     /**
@@ -260,74 +283,135 @@ public class Southpaw {
         List<String> rootEntities = Arrays.stream(relations).map(Relation::getEntity).collect(Collectors.toList());
         topics.sort((x, y) -> Boolean.compare(rootEntities.contains(x.getKey()), rootEntities.contains(y.getKey())));
 
-        while(processRecords) {
-            // Loop through each input topic and read a batch of records
+        Map<String, String> tablesToAlias = new HashMap<>();
+        inputTopics.entrySet().stream().forEach((e) -> {
+            String tableName = e.getValue().getTableName();
+            if (tableName == null) {
+                tableName = e.getValue().getTopicName();
+                tableName = topicsPrefixed?tableName.substring(tableName.indexOf('.')+1):tableName;
+            }
+            tablesToAlias.put(tableName, e.getKey());
+        });
+        Map<String, Integer> transactionEvents = new HashMap<>();
 
+        Map<String, RecordHolder> allHolders = new LinkedHashMap<String, Southpaw.RecordHolder>();
+        for (Map.Entry<String, BaseTopic<BaseRecord, BaseRecord>> entry : topics) {
+            RecordHolder holder = new RecordHolder();
+            holder.entity = entry.getKey();
+            holder.inputTopic = entry.getValue();
+            holder.records = holder.inputTopic.readNext();
+            holder.txnTopic = TRANSACTIONS.equals(holder.entity);
+            allHolders.put(holder.entity, holder);
+        }
+        Map<String, RecordHolder> toProcess = new LinkedHashMap<>(allHolders);
+
+        process: while(processRecords) {
+            // Loop through each input topic and read a batch of records
             boolean foundAny = false;
-            for (Map.Entry<String, BaseTopic<BaseRecord, BaseRecord>> entry : topics) {
-                String entity = entry.getKey();
-                BaseTopic<BaseRecord, BaseRecord> inputTopic = entry.getValue();
+            for (Iterator<RecordHolder> iter = toProcess.values().iterator(); iter.hasNext();) {
+                RecordHolder holder = iter.next();
+                String entity = holder.entity;
+                BaseTopic<BaseRecord, BaseRecord> inputTopic = holder.inputTopic;
 
                 long topicLag;
                 calculateRecordsToCreate();
                 calculateTotalLag();
 
                 do {
-                    ConsumerRecordIterator<BaseRecord, BaseRecord> records = inputTopic.readNext();
-                    if (records.getApproximateCount() > 0) {
+                    if (!holder.records.hasNext()) {
+                        holder.records = inputTopic.readNext();
+                        if (holder.records.getApproximateCount() > 0) {
+                            foundAny = true;
+                        }
+                    } else {
                         foundAny = true;
                     }
                     // Loop through each record and process it
-                    while (records.hasNext()) {
-                        ConsumerRecord<BaseRecord, BaseRecord> newRecord = records.next();
-                        ByteArray primaryKey = newRecord.key().toByteArray();
-                        for (Relation root : relations) {
-                            Set<ByteArray> dePrimaryKeys = dePKsByType.get(root);
-                            if (root.getEntity().equals(entity)) {
-                                // The top level relation is the relation of the input record
-                                dePrimaryKeys.add(primaryKey);
-                            } else {
-                                // Check the child relations instead
-                                AbstractMap.SimpleEntry<Relation, Relation> child = getRelation(root, entity);
-                                if (child != null && child.getValue() != null) {
-                                    BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> parentIndex =
-                                            fkIndices.get(createParentIndexName(root, child.getKey(), child.getValue()));
-                                    ByteArray newParentKey = null;
-                                    Set<ByteArray> oldParentKeys;
-                                    if (newRecord.value() != null) {
-                                        newParentKey = ByteArray.toByteArray(newRecord.value().get(child.getValue().getJoinKey()));
+                    while (holder.records.hasNext()) {
+                        if (transactional) {
+                            BaseRecord baseRecord = holder.records.peekValue();
+                            String txn = null;
+                            if (holder.txnTopic) {
+                                String status = (String)baseRecord.get("status");
+                                txn = (String)baseRecord.get("id");
+                                if ("BEGIN".equals(status)) {
+                                    if(logger.isDebugEnabled()) {
+                                        logger.debug("starting transaction {}", txn);
                                     }
-                                    BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> joinIndex =
-                                            fkIndices.get(createJoinIndexName(child.getValue()));
-                                    oldParentKeys = ((Reversible) joinIndex).getForeignKeys(primaryKey);
-
-                                    // Create the denormalized records
-                                    if (oldParentKeys != null) {
-                                        for (ByteArray oldParentKey : oldParentKeys) {
-                                            if (!ObjectUtils.equals(oldParentKey, newParentKey)) {
-                                                Set<ByteArray> primaryKeys = parentIndex.getIndexEntry(oldParentKey);
-                                                if (primaryKeys != null) {
-                                                    dePrimaryKeys.addAll(primaryKeys);
-                                                }
-                                            }
+                                    transactionEvents.clear();
+                                    if (currentTxn != null) {
+                                        throw new AssertionError("Unexpected begin of transaction");
+                                    }
+                                    currentTxn = txn;
+                                    toProcess.clear();
+                                    toProcess.putAll(allHolders);
+                                    iter = toProcess.values().iterator();
+                                } else if ("END".equals(status)) {
+                                    if (!txn.equals(currentTxn)) {
+                                        throw new AssertionError("Unexpected end of transaction");
+                                    }
+                                    List<Map<String, ?>> dataCollections = (List<Map<String, ?>>) baseRecord.get("data_collections");
+                                    toProcess.clear();
+                                    for (Map<String, ?> dataCollection : dataCollections) {
+                                        String topic = (String)dataCollection.get("data_collection");
+                                        String alias = tablesToAlias.get(topic);
+                                        if (alias == null) {
+                                            continue; //not involved
+                                        }
+                                        int eventCount = ((Number)dataCollection.get("event_count")).intValue();
+                                        if (!seenTxnEnd) {
+                                            accumulateEventCount(transactionEvents, alias, -eventCount);
+                                        }
+                                        if (transactionEvents.containsKey(alias)) {
+                                            logger.debug("waiting for {}", alias);
+                                            toProcess.put(alias, allHolders.get(alias));
                                         }
                                     }
-                                    if (newParentKey != null) {
-                                        Set<ByteArray> primaryKeys = parentIndex.getIndexEntry(newParentKey);
-                                        if (primaryKeys != null) {
-                                            dePrimaryKeys.addAll(primaryKeys);
-                                        }
+                                    seenTxnEnd = true;
+                                    if (!toProcess.isEmpty()) {
+                                        continue process;
                                     }
-                                    // Update the join index
-                                    updateJoinIndex(child.getValue(), primaryKey, newRecord);
+                                    toProcess.putAll(allHolders);
+                                    iter = toProcess.values().iterator();
+                                    //commit
+                                    currentTxn = null;
+                                    seenTxnEnd = false;
+                                    if(logger.isDebugEnabled()) {
+                                        logger.debug("ending transaction {}", txn);
+                                    }
+                                    flushDenormalized();
+                                }
+                            } else if (baseRecord != null) {
+                                Map<String, ?> metadata = baseRecord.getMetadata();
+                                if (metadata != null) {
+                                    Map<String, ?> transaction = (Map<String, ?>) metadata.get("transaction");
+                                    if (transaction != null) {
+                                        txn = (String)transaction.get("id");
+                                    }
+                                }
+                                if (txn != null) {
+                                    if (currentTxn != null && txn.equals(currentTxn)) {
+                                        accumulateEventCount(transactionEvents, entity, 1);
+                                        if (transactionEvents.isEmpty()) {
+                                            //remove myself from the processing list and wait for txn event
+                                            toProcess.remove(entity);
+                                            toProcess.put(TRANSACTIONS, allHolders.get(TRANSACTIONS));
+                                            iter = toProcess.values().iterator();
+                                            //consume the event
+                                        }
+                                    } else {
+                                        //remove myself from the processing list and wait for txn event
+                                        toProcess.remove(entity);
+                                        toProcess.put(TRANSACTIONS, allHolders.get(TRANSACTIONS));
+                                        continue process;
+                                    }
                                 }
                             }
-                            int size = dePrimaryKeys.size();
-                            if(size > config.createRecordsTrigger) {
-                                createDenormalizedRecords(root, dePrimaryKeys);
-                                dePrimaryKeys.clear();
-                            }
-                            metrics.denormalizedRecordsToCreateByTopic.get(root.getDenormalizedName()).update((long) size);
+                        }
+                        ConsumerRecord<BaseRecord, BaseRecord> newRecord = holder.records.next();
+
+                        if (!holder.txnTopic) {
+                            processRecord(entity, newRecord);
                         }
                         metrics.recordsConsumed.mark(1);
                         metrics.recordsConsumedByTopic.get(entity).mark(1);
@@ -339,27 +423,29 @@ public class Southpaw {
                     reportRecordsToCreate();
                     reportTotalLag();
 
-                    if(
-                            (config.backupTimeS > 0 && backupWatch.getTime() > config.backupTimeS * 1000)
-                            || (runWatch.getTime() > runTimeS * 1000 && runTimeS > 0)) {
-                        try(Timer.Context context = metrics.backupsCreated.time()) {
-                            logger.info("Performing a backup after a full commit");
-                            calculateRecordsToCreate();
-                            calculateTotalLag();
-                            commit();
-                            state.backup();
-                            backupWatch.reset();
-                            backupWatch.start();
-                            if (runWatch.getTime() > runTimeS * 1000 && runTimeS > 0) return;
-                        }
-                    } else if(config.commitTimeS > 0 && commitWatch.getTime() > config.commitTimeS * 1000) {
-                        try(Timer.Context context = metrics.stateCommitted.time()) {
-                            logger.info("Performing a full commit");
-                            calculateRecordsToCreate();
-                            calculateTotalLag();
-                            commit();
-                            commitWatch.reset();
-                            commitWatch.start();
+                    if (currentTxn == null) {
+                        if(
+                                (config.backupTimeS > 0 && backupWatch.getTime() > config.backupTimeS * 1000)
+                                || (runWatch.getTime() > runTimeS * 1000 && runTimeS > 0)) {
+                            try(Timer.Context context = metrics.backupsCreated.time()) {
+                                logger.info("Performing a backup after a full commit");
+                                calculateRecordsToCreate();
+                                calculateTotalLag();
+                                commit();
+                                state.backup();
+                                backupWatch.reset();
+                                backupWatch.start();
+                                if (runWatch.getTime() > runTimeS * 1000 && runTimeS > 0) return;
+                            }
+                        } else if(config.commitTimeS > 0 && commitWatch.getTime() > config.commitTimeS * 1000) {
+                            try(Timer.Context context = metrics.stateCommitted.time()) {
+                                logger.info("Performing a full commit");
+                                calculateRecordsToCreate();
+                                calculateTotalLag();
+                                commit();
+                                commitWatch.reset();
+                                commitWatch.start();
+                            }
                         }
                     }
                 } while (topicLag > config.topicLagTrigger);
@@ -376,12 +462,99 @@ public class Southpaw {
             }
 
             // Create the denormalized records that have been queued up
-            for(Map.Entry<Relation, ByteArraySet> entry: dePKsByType.entrySet()) {
-                createDenormalizedRecords(entry.getKey(), entry.getValue());
-                entry.getValue().clear();
-            }
+            flushDenormalized();
         }
         commit();
+    }
+
+    /**
+     * Accumulate the running total - a 0 total is removed from the map.
+     * @param transactionEvents the map of events
+     * @param alias short name
+     * @param eventCount the count to accumulate
+     */
+    private void accumulateEventCount(Map<String, Integer> transactionEvents, String alias, int eventCount) {
+        transactionEvents.compute(alias, (k, v)->{
+            if (v==null) {
+                return eventCount;
+            }
+            int i = v+eventCount;
+            if (i == 0) {
+                return null;
+            }
+            return i;
+        });
+    }
+
+    /**
+     * Write out all pending denormalized
+     */
+    private void flushDenormalized() {
+        if (currentTxn != null) {
+            return;
+        }
+        for(Map.Entry<Relation, ByteArraySet> entry: dePKsByType.entrySet()) {
+            createDenormalizedRecords(entry.getKey(), entry.getValue());
+            entry.getValue().clear();
+        }
+    }
+
+    /**
+     * Process a single record
+     * @param entity topic short name
+     * @param newRecord the record to process
+     */
+    private void processRecord(String entity, ConsumerRecord<BaseRecord, BaseRecord> newRecord) {
+        ByteArray primaryKey = newRecord.key().toByteArray();
+        for (Relation root : relations) {
+            Set<ByteArray> dePrimaryKeys = dePKsByType.get(root);
+            if (root.getEntity().equals(entity)) {
+                // The top level relation is the relation of the input record
+                dePrimaryKeys.add(primaryKey);
+            } else {
+                // Check the child relations instead
+                AbstractMap.SimpleEntry<Relation, Relation> child = getRelation(root, entity);
+                if (child != null && child.getValue() != null) {
+                    BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> parentIndex =
+                            fkIndices.get(createParentIndexName(root, child.getKey(), child.getValue()));
+                    ByteArray newParentKey = null;
+                    Set<ByteArray> oldParentKeys;
+                    if (newRecord.value() != null) {
+                        newParentKey = ByteArray.toByteArray(newRecord.value().get(child.getValue().getJoinKey()));
+                    }
+                    BaseIndex<BaseRecord, BaseRecord, Set<ByteArray>> joinIndex =
+                            fkIndices.get(createJoinIndexName(child.getValue()));
+                    oldParentKeys = ((Reversible) joinIndex).getForeignKeys(primaryKey);
+
+                    // Create the denormalized records
+                    if (oldParentKeys != null) {
+                        for (ByteArray oldParentKey : oldParentKeys) {
+                            if (!ObjectUtils.equals(oldParentKey, newParentKey)) {
+                                Set<ByteArray> primaryKeys = parentIndex.getIndexEntry(oldParentKey);
+                                if (primaryKeys != null) {
+                                    dePrimaryKeys.addAll(primaryKeys);
+                                }
+                            }
+                        }
+                    }
+                    if (newParentKey != null) {
+                        Set<ByteArray> primaryKeys = parentIndex.getIndexEntry(newParentKey);
+                        if (primaryKeys != null) {
+                            dePrimaryKeys.addAll(primaryKeys);
+                        }
+                    }
+                    // Update the join index
+                    updateJoinIndex(child.getValue(), primaryKey, newRecord);
+                }
+            }
+            int size = dePrimaryKeys.size();
+            if(currentTxn == null && size > config.createRecordsTrigger) {
+                createDenormalizedRecords(root, dePrimaryKeys);
+                dePrimaryKeys.clear();
+                size = 0;
+            }
+            metrics.denormalizedRecordsToCreateByTopic.get(root.getDenormalizedName()).update((long) size);
+        }
     }
 
     /**

--- a/src/main/java/com/jwplayer/southpaw/filter/BaseFilter.java
+++ b/src/main/java/com/jwplayer/southpaw/filter/BaseFilter.java
@@ -15,14 +15,15 @@
  */
 package com.jwplayer.southpaw.filter;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jmx.JmxReporter;
 import com.jwplayer.southpaw.record.BaseRecord;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 
 /**
@@ -79,11 +80,11 @@ public class BaseFilter {
 
     /**
      * Used to inform how a record should be handled:
-     * 
+     *
      * UPDATE: Do not filter (no op) by advancing offset and updating state, output record produced.
      * SKIP: Skip record and advance offset, don't update state, output record not produced.
      * DELETE: Delete record by advancing offset and updating state, output record produced.
-     * 
+     *
      */
     public enum FilterMode { UPDATE, SKIP, DELETE }
 
@@ -100,10 +101,10 @@ public class BaseFilter {
      *
      * @param entity - The entity of the given record
      * @param record - The record to filter
-     * @param oldRecord - The previously seen record state (may be null)
+     * @param oldRecordSupplier - The Supplier of the previously seen record state (may be null)
      * @return FilterMode - Describes how to handle the input record
      */
-    protected FilterMode customFilter(String entity, BaseRecord record, BaseRecord oldRecord) {
+    protected FilterMode customFilter(String entity, BaseRecord record, Supplier<BaseRecord> oldRecordSupplier) {
         return FilterMode.UPDATE;
     }
 
@@ -140,18 +141,18 @@ public class BaseFilter {
 
     /**
      * Determines if the given record should be filtered based on its entity and previous entity state.
-     * 
+     *
      * @param entity - The entity of the given record
      * @param record - The record to filter
      * @param oldRecord - The previously seen record state (may be null)
      * @return FilterMode - Describes how to handle the input record
      */
-    public FilterMode filter(String entity, BaseRecord record, BaseRecord oldRecord) {
+    public FilterMode filter(String entity, BaseRecord record, Supplier<BaseRecord> lookup) {
         FilterMode mode;
         if (record == null || record.isEmpty()) {
             mode = FilterMode.DELETE;
         } else {
-            mode = customFilter(entity, record, oldRecord);
+            mode = customFilter(entity, record, lookup);
         }
 
         metrics.getMeter(entity, mode).mark(1);

--- a/src/main/java/com/jwplayer/southpaw/record/BaseRecord.java
+++ b/src/main/java/com/jwplayer/southpaw/record/BaseRecord.java
@@ -15,17 +15,20 @@
  */
 package com.jwplayer.southpaw.record;
 
-import com.jwplayer.southpaw.util.ByteArray;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import com.jwplayer.southpaw.util.ByteArray;
 
 
 /**
  * A record abstraction for standardizing and exposing some basic functionality.
  */
 public abstract class BaseRecord {
+
+    private Map<String, ?> metadata;
+
     /**
      * Accessor for a particular field in this record
      * @param fieldName - The name of the field to get
@@ -78,7 +81,20 @@ public abstract class BaseRecord {
      * Gives a friendly string representation of the object. Particularly useful for debugging in Intellij.
      * @return The string representation of this object.
      */
+    @Override
     public String toString() {
         return toMap().toString();
+    }
+
+    /**
+     * Metadata associated with the record to be used in initial processing decisions.
+     * @return
+     */
+    public Map<String, ?> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, ?> metadata) {
+        this.metadata = metadata;
     }
 }

--- a/src/main/java/com/jwplayer/southpaw/record/MapRecord.java
+++ b/src/main/java/com/jwplayer/southpaw/record/MapRecord.java
@@ -15,10 +15,10 @@
  */
 package com.jwplayer.southpaw.record;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
 
 
 /**
@@ -57,6 +57,6 @@ public class MapRecord extends BaseRecord {
     @Override
     public Map<String, ?> toMap() {
         if(internalRecord == null) return ImmutableMap.of();
-        return ImmutableMap.copyOf(internalRecord);
+        return internalRecord;
     }
 }

--- a/src/main/java/com/jwplayer/southpaw/serde/DebeziumJsonSerde.java
+++ b/src/main/java/com/jwplayer/southpaw/serde/DebeziumJsonSerde.java
@@ -59,7 +59,7 @@ public class DebeziumJsonSerde implements BaseSerde<BaseRecord> {
                 }
                 Map<String, ?> after = (Map<String, ?>) envelope.get("after");
                 MapRecord result = new MapRecord(after);
-                //result.setMetadata(envelope);
+                result.setMetadata(envelope);
                 return result;
             }
 

--- a/src/main/java/com/jwplayer/southpaw/serde/DebeziumJsonSerde.java
+++ b/src/main/java/com/jwplayer/southpaw/serde/DebeziumJsonSerde.java
@@ -1,0 +1,78 @@
+package com.jwplayer.southpaw.serde;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+
+import com.jwplayer.southpaw.record.BaseRecord;
+import com.jwplayer.southpaw.record.MapRecord;
+
+import io.confluent.kafka.serializers.KafkaJsonDeserializer;
+
+/**
+ * Combines key/value parsing.  This is really not desirable, but follows the pattern of the other Serde classes.
+ * It would be better to have separate key and value
+ *  - key can be a simple type or BaseRecord, and value can be BaseRecord.
+ *
+ * Alternatively this could be implemented using JsonNode and a new {@link BaseRecord} type.
+ */
+public class DebeziumJsonSerde implements BaseSerde<BaseRecord> {
+
+    KafkaJsonDeserializer<Map<String, ?>> internalDeserializer = new KafkaJsonDeserializer<>();
+    boolean isKey = false;
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        internalDeserializer.configure(configs, isKey);
+        this.isKey = isKey;
+    }
+
+    @Override
+    public void close() {
+        internalDeserializer.close();
+    }
+
+    @Override
+    public Serializer<BaseRecord> serializer() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Deserializer<BaseRecord> deserializer() {
+        return new Deserializer<BaseRecord>() {
+
+            @Override
+            public BaseRecord deserialize(String topic, byte[] data) {
+                Map<String, ?> envelope = internalDeserializer.deserialize(topic, data);
+                if (envelope == null) {
+                    return null; //tombstone
+                }
+                if (isKey || envelope.get("source") == null) {
+                    if (envelope instanceof Map) {
+                        return new MapRecord(envelope);
+                    }
+                    //provide a wrapper for a non-object type
+                    return new MapRecord(Collections.singletonMap("id", envelope));
+                }
+                Map<String, ?> after = (Map<String, ?>) envelope.get("after");
+                MapRecord result = new MapRecord(after);
+                //result.setMetadata(envelope);
+                return result;
+            }
+
+            @Override
+            public void configure(Map<String, ?> configs, boolean isKey) {
+                throw new NotImplementedException();
+            }
+
+            @Override
+            public void close() {
+                throw new NotImplementedException();
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/jwplayer/southpaw/topic/BaseTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/BaseTopic.java
@@ -204,4 +204,12 @@ public abstract class BaseTopic<K, V> {
      * @param value - The serialized value.
      */
     public abstract void write(K key, V value);
+
+    /**
+     * Name of the table referenced in transaction metadata
+     * @return
+     */
+    public String getTableName() {
+        return null;
+    }
 }

--- a/src/main/java/com/jwplayer/southpaw/topic/BaseTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/BaseTopic.java
@@ -15,15 +15,12 @@
  */
 package com.jwplayer.southpaw.topic;
 
-import com.jwplayer.southpaw.util.ByteArray;
-import com.jwplayer.southpaw.topic.TopicConfig;
-import com.jwplayer.southpaw.filter.BaseFilter;
-import com.jwplayer.southpaw.state.BaseState;
-import com.jwplayer.southpaw.metric.Metrics;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serde;
 
-import java.util.Iterator;
+import com.jwplayer.southpaw.filter.BaseFilter;
+import com.jwplayer.southpaw.metric.Metrics;
+import com.jwplayer.southpaw.state.BaseState;
+import com.jwplayer.southpaw.util.ByteArray;
 
 
 /**
@@ -178,7 +175,7 @@ public abstract class BaseTopic<K, V> {
      * Reads records in topic based on the current offset.
      * @return The list of records read.
      */
-    public abstract Iterator<ConsumerRecord<K, V>> readNext();
+    public abstract ConsumerRecordIterator<K, V> readNext();
 
     /**
      * Resets the current offset to the beginning of the topic.
@@ -189,6 +186,7 @@ public abstract class BaseTopic<K, V> {
      * Gives a nicely formatted string representation of this object. Useful for the Intellij debugger.
      * @return Formatted string representation of this object
      */
+    @Override
     public String toString() {
         return String.format(
                 "{shortName=%s,topicName=%s,currentOffset=%s,keySerde=%s,valueSerde=%s}",

--- a/src/main/java/com/jwplayer/southpaw/topic/BlackHoleTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/BlackHoleTopic.java
@@ -15,11 +15,9 @@
  */
 package com.jwplayer.southpaw.topic;
 
-import com.jwplayer.southpaw.util.ByteArray;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.commons.lang.NotImplementedException;
 
-import java.util.Iterator;
+import com.jwplayer.southpaw.util.ByteArray;
 
 
 public class BlackHoleTopic<K, V> extends BaseTopic<K, V> {
@@ -49,7 +47,7 @@ public class BlackHoleTopic<K, V> extends BaseTopic<K, V> {
     }
 
     @Override
-    public Iterator<ConsumerRecord<K, V>> readNext() {
+    public ConsumerRecordIterator<K, V> readNext() {
         throw new NotImplementedException();
     }
 

--- a/src/main/java/com/jwplayer/southpaw/topic/ConsoleTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/ConsoleTopic.java
@@ -15,13 +15,11 @@
  */
 package com.jwplayer.southpaw.topic;
 
-import com.jwplayer.southpaw.record.BaseRecord;
-import com.jwplayer.southpaw.util.ByteArray;
-import com.jwplayer.southpaw.filter.BaseFilter.FilterMode;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.commons.lang.NotImplementedException;
 
-import java.util.Iterator;
+import com.jwplayer.southpaw.filter.BaseFilter.FilterMode;
+import com.jwplayer.southpaw.record.BaseRecord;
+import com.jwplayer.southpaw.util.ByteArray;
 
 
 public class ConsoleTopic<K, V> extends BaseTopic<K, V> {
@@ -51,7 +49,7 @@ public class ConsoleTopic<K, V> extends BaseTopic<K, V> {
     }
 
     @Override
-    public Iterator<ConsumerRecord<K, V>> readNext() {
+    public ConsumerRecordIterator<K, V> readNext() {
         throw new NotImplementedException();
     }
 

--- a/src/main/java/com/jwplayer/southpaw/topic/ConsumerRecordIterator.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/ConsumerRecordIterator.java
@@ -8,4 +8,6 @@ public interface ConsumerRecordIterator<K, V> extends Iterator<ConsumerRecord<K,
 
     int getApproximateCount();
 
+    V peekValue();
+
 }

--- a/src/main/java/com/jwplayer/southpaw/topic/ConsumerRecordIterator.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/ConsumerRecordIterator.java
@@ -1,0 +1,11 @@
+package com.jwplayer.southpaw.topic;
+
+import java.util.Iterator;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface ConsumerRecordIterator<K, V> extends Iterator<ConsumerRecord<K, V>>{
+
+    int getApproximateCount();
+
+}

--- a/src/main/java/com/jwplayer/southpaw/topic/InMemoryTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/InMemoryTopic.java
@@ -121,6 +121,11 @@ public final class InMemoryTopic<K, V> extends BaseTopic<K, V> {
             public ConsumerRecord<K, V> next() {
                 return retVal.get(index++);
             }
+
+            @Override
+            public V peekValue() {
+                return retVal.get(index).value();
+            }
         };
     }
 

--- a/src/main/java/com/jwplayer/southpaw/topic/InMemoryTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/InMemoryTopic.java
@@ -15,12 +15,17 @@
  */
 package com.jwplayer.southpaw.topic;
 
-import com.jwplayer.southpaw.record.BaseRecord;
-import com.jwplayer.southpaw.util.ByteArray;
-import com.jwplayer.southpaw.filter.BaseFilter.FilterMode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import java.util.*;
+import com.jwplayer.southpaw.filter.BaseFilter.FilterMode;
+import com.jwplayer.southpaw.record.BaseRecord;
+import com.jwplayer.southpaw.util.ByteArray;
 
 
 /**
@@ -93,13 +98,30 @@ public final class InMemoryTopic<K, V> extends BaseTopic<K, V> {
     }
 
     @Override
-    public Iterator<ConsumerRecord<K, V>> readNext() {
+    public ConsumerRecordIterator<K, V> readNext() {
         List<ConsumerRecord<K, V>> retVal = new ArrayList<>();
         while(records.size() + firstOffset > currentOffset + 1) {
             currentOffset++;
             retVal.add(records.get(((Long) (currentOffset - firstOffset)).intValue()));
         }
-        return retVal.iterator();
+        return new ConsumerRecordIterator<K, V>() {
+            int index = 0;
+
+            @Override
+            public int getApproximateCount() {
+                return retVal.size();
+            }
+
+            @Override
+            public boolean hasNext() {
+                return index < retVal.size();
+            }
+
+            @Override
+            public ConsumerRecord<K, V> next() {
+                return retVal.get(index++);
+            }
+        };
     }
 
     @Override

--- a/src/main/java/com/jwplayer/southpaw/topic/KafkaTopic.java
+++ b/src/main/java/com/jwplayer/southpaw/topic/KafkaTopic.java
@@ -52,8 +52,10 @@ import com.jwplayer.southpaw.util.ByteArray;
  */
 public class KafkaTopic<K, V> extends BaseTopic<K, V> {
     public static final long END_OFFSET_REFRESH_MS_DEFAULT = 60000;
+
     public static final String PERSISTENT = "persistent";
     public static final boolean PERSISTENT_DEFAULT = true;
+    public static final String TABLE_NAME = "table.name";
     /**
      * Le Logger
      */
@@ -98,6 +100,11 @@ public class KafkaTopic<K, V> extends BaseTopic<K, V> {
         @Override
         public int getApproximateCount() {
             return approximateCount;
+        }
+
+        @Override
+        public V peekValue() {
+            return nextValue;
         }
 
         /**
@@ -296,8 +303,15 @@ public class KafkaTopic<K, V> extends BaseTopic<K, V> {
      * The callback for Kafka producer writes
      */
     private final Callback producerCallback = new KafkaProducerCallback();
+    /**
+     * If the values for this topic should be saved
+     */
     private boolean persistent;
     private TopicPartition topicPartition;
+    /**
+     * The table name associated with this topic if transactional
+     */
+    private String tableName;
 
     @Override
     public void commit() {
@@ -352,6 +366,7 @@ public class KafkaTopic<K, V> extends BaseTopic<K, V> {
         }
 
         this.persistent = (Boolean)spConfig.getOrDefault(PERSISTENT, PERSISTENT_DEFAULT);
+        this.tableName = (String)spConfig.getOrDefault(TABLE_NAME, null);
     }
 
     @Override
@@ -442,5 +457,10 @@ public class KafkaTopic<K, V> extends BaseTopic<K, V> {
 
     public void setPollTimeout(long pollTimeout) {
         this.pollTimeout = pollTimeout;
+    }
+
+    @Override
+    public String getTableName() {
+        return this.tableName;
     }
 }

--- a/src/test/java/com/jwplayer/southpaw/filter/TestFilter.java
+++ b/src/test/java/com/jwplayer/southpaw/filter/TestFilter.java
@@ -15,6 +15,8 @@
  */
 package com.jwplayer.southpaw.filter;
 
+import java.util.function.Supplier;
+
 import com.jwplayer.southpaw.record.BaseRecord;
 
 public class TestFilter extends BaseFilter {
@@ -24,8 +26,9 @@ public class TestFilter extends BaseFilter {
 
     public TestFilter() {}
 
+
     @Override
-    public FilterMode customFilter(String entity, BaseRecord record, BaseRecord oldRecord) {
+    protected FilterMode customFilter(String entity, BaseRecord record, Supplier<BaseRecord> oldRecordSupplier) {
         FilterMode mode = FilterMode.UPDATE;
         switch(entity) {
             case "media":

--- a/src/test/java/com/jwplayer/southpaw/topic/KafkaTopicTest.java
+++ b/src/test/java/com/jwplayer/southpaw/topic/KafkaTopicTest.java
@@ -15,21 +15,27 @@
  */
 package com.jwplayer.southpaw.topic;
 
-import com.jwplayer.southpaw.MockState;
-import com.jwplayer.southpaw.filter.BaseFilter;
-import com.jwplayer.southpaw.state.BaseState;
-import com.jwplayer.southpaw.util.ByteArray;
-import com.jwplayer.southpaw.util.KafkaTestServer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.serialization.Serdes;
-import org.junit.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.jwplayer.southpaw.MockState;
+import com.jwplayer.southpaw.filter.BaseFilter;
+import com.jwplayer.southpaw.state.BaseState;
+import com.jwplayer.southpaw.util.ByteArray;
+import com.jwplayer.southpaw.util.KafkaTestServer;
 
 
 public class KafkaTopicTest {
@@ -42,6 +48,7 @@ public class KafkaTopicTest {
     public KafkaTopic<String, String> createTopic(String topicName) {
         kafkaServer.createTopic(topicName, 1);
         KafkaTopic<String, String> topic = new KafkaTopic<>();
+        topic.setPollTimeout(100);
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer.getConnectionString());
         config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);

--- a/test-resources/config.sample.yaml
+++ b/test-resources/config.sample.yaml
@@ -27,7 +27,6 @@ topics:
     filter.class: "com.jwplayer.southpaw.filter.TestFilter"
     group.id: "southpaw"
     key.serde.class: "com.jwplayer.southpaw.serde.JsonSerde"
-    poll.timeout: 100
     schema.registry.url: "http://schema-registry:8081"
     topic.class: "com.jwplayer.southpaw.topic.InMemoryTopic"
     value.serde.class: "com.jwplayer.southpaw.serde.JsonSerde"


### PR DESCRIPTION
There are some things here that could be teased apart, but it is probably good just to see what it's working towards.  This was done for a POC of honoring transactaional metadata produced by Debezium - in particular for postgresql.

With a config that includes new serdes and a transactions topic, such as:

```
topics:
  default:
    acks: "all"
    auto.offset.reset: "earliest"
    bootstrap.servers: "localhost:9092"
    client.id: "southpaw"
    group.id: "southpaw"
    enable.auto.commit: false
    key.serde.class: "com.jwplayer.southpaw.serde.DebeziumJsonSerde"
    schema.registry.url: "http://localhost:80"
    topic.class: "com.jwplayer.southpaw.topic.KafkaTopic"
    value.serde.class: "com.jwplayer.southpaw.serde.DebeziumJsonSerde"
  CustomerWithAddresses:
    compression.type: "snappy"
    jackson.serde.class: "com.jwplayer.southpaw.json.DenormalizedRecord"
    key.serde.class: "org.apache.kafka.common.serialization.Serdes$ByteArraySerde"
    topic.class: "com.jwplayer.southpaw.topic.KafkaTopic"
    topic.name: "customers-with-addresses"
    value.serde.class: "com.jwplayer.southpaw.serde.JacksonSerde"
  customer:
    topic.name: "dbserver1.inventory.customers"
  address:
    topic.name: "dbserver1.inventory.addresses"
  transactions:
    topic.name: "dbserver1.transaction"
    value.serde.class: "com.jwplayer.southpaw.serde.JsonSerde"
    key.serde.class: "com.jwplayer.southpaw.serde.JsonSerde"
    persistent: false
```

One can consume the events from https://github.com/debezium/debezium-examples/tree/master/kstreams-fk-join with the connector configured with "provide.transaction.metadata": "true" and emit denormalizations that are consistent with the transaction boundaries.  It also degrades if transaction metadata is not available to the normal eventually consistent processing.  Please reach out if something like that is of interest.

In the earliest commit I'm trying to address redundant or unnecessary deserialization by holding onto the deserialized value and making getting the old value for filtering optional.  It also add support for wrapped debezium json cdc events.

In the next commit there's code to make for a tighter polling loop to avoid setting or incurring a polling timeout on topics that don't change much.

Let me know if you want separate PRs for those changes.