### PR TITLE
Fix backup path when using an s3 uri

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
+++ b/src/main/java/com/jwplayer/southpaw/state/RocksDBState.java
@@ -336,9 +336,10 @@ public class RocksDBState extends BaseState {
             this.restoreMode = RestoreMode.parse(config.getOrDefault(RESTORE_MODE_CONFIG, RestoreMode.NEVER.getValue()).toString());
             this.uri = new URI(Preconditions.checkNotNull(config.get(URI_CONFIG).toString()));
 
+            // TODO: We need to split S3 persistence out of RocksDBState. It doesn't belong here
             if(backupURI.getScheme().toLowerCase().equals(S3Helper.SCHEME)) {
                 s3Helper = new S3Helper(config);
-                backupPath = getLocalBackupPath(backupURI);
+                backupPath = getLocalBackupPath(uri);
             } else {
                 backupPath = backupURI.getPath();
             }
@@ -464,7 +465,7 @@ public class RocksDBState extends BaseState {
         logger.info("Finished opening RocksDB state");
     }
 
-    private void openBackupEngine() throws RocksDBException{
+    protected void openBackupEngine() throws RocksDBException{
         if (backupEngine == null) {
             logger.info("Opening RocksDB backup engine");
             backupOptions = new BackupableDBOptions(backupPath)

--- a/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
+++ b/src/test/java/com/jwplayer/southpaw/state/RocksDBStateTest.java
@@ -19,6 +19,9 @@ import com.jwplayer.southpaw.util.ByteArray;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.rocksdb.BackupEngine;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -707,6 +710,32 @@ public class RocksDBStateTest {
         }
         // Local database was used which has more recent data than the backup
         assertEquals(200, (int) count);
+    }
+
+    @Test
+    public void openBackupEngineBackup() throws RocksDBException {
+        Map<String, Object> config = createConfig(dbUri, backupUri);
+
+        assertNull(state.backupEngine);
+        state.configure(config);
+        state.openBackupEngine();
+
+        assertNotNull(state.backupEngine);
+    }
+
+    @Test
+    public void openBackupEngineS3Backup() throws RocksDBException {
+        String s3BackupUri = "s3://test-bucket";
+        Map<String, Object> config = createConfig(dbUri, s3BackupUri);
+        config.put("aws.s3.access.key.id", "foo");
+        config.put("aws.s3.access.key", "bar");
+        config.put("aws.s3.region", "us-east-1");
+
+        assertNull(state.backupEngine);
+        state.configure(config);
+        state.openBackupEngine();
+
+        assertNotNull(state.backupEngine);
     }
 
     @Test


### PR DESCRIPTION
Fixes a regression introduced in #67. When the `rocks.db.backup.uri` config value was set to an `s3://` URI the `backupPath` was being set to the S3 bucket name which was failing to get created and subsequently causing the RocksDB BackupEngine to fail to open since the file path it was mounting to didn't exist. This fixes the behavior to how it worked befire #67 where it would call `getLocalBackupPath` with the `uri` and not the `backupURI` value.

- Changed `openBackupEngine` to protected for access in testing
- Added a TODO for splitting S3 logic out of the RocksDBState class itself as the way it's setup currently makes testing difficult as well as adds complexity to configuration logic 