### PR TITLE
[BIG-5270] - Reset commit timer every commit call

### DIFF
--- a/src/main/java/com/jwplayer/southpaw/Southpaw.java
+++ b/src/main/java/com/jwplayer/southpaw/Southpaw.java
@@ -140,6 +140,11 @@ public class Southpaw {
     protected BaseState state;
 
     /**
+     * Timer for when to initiate incremental commit
+     */
+    private StopWatch commitWatch;
+
+    /**
      * Base Southpaw config
      */
     protected static class Config {
@@ -236,11 +241,13 @@ public class Southpaw {
      */
     protected void build(int runTimeS) {
         logger.info("Building denormalized records");
+
         StopWatch backupWatch = new StopWatch();
         backupWatch.start();
         StopWatch runWatch = new StopWatch();
         runWatch.start();
-        StopWatch commitWatch = new StopWatch();
+
+        commitWatch = new StopWatch();
         commitWatch.start();
 
         List<Map.Entry<String, BaseTopic<BaseRecord, BaseRecord>>> topics = new ArrayList<>(inputTopics.entrySet());
@@ -326,23 +333,22 @@ public class Southpaw {
                             (config.backupTimeS > 0 && backupWatch.getTime() > config.backupTimeS * 1000)
                             || (runWatch.getTime() > runTimeS * 1000 && runTimeS > 0)) {
                         try(Timer.Context context = metrics.backupsCreated.time()) {
-                            logger.info("Performing a backup after a full commit");
+                            logger.info("Performing southpaw backup");
                             calculateRecordsToCreate();
                             calculateTotalLag();
                             commit();
                             state.backup();
                             backupWatch.reset();
                             backupWatch.start();
+                            logger.info("Finished performing southpaw backup");
                             if (runWatch.getTime() > runTimeS * 1000 && runTimeS > 0) return;
                         }
                     } else if(config.commitTimeS > 0 && commitWatch.getTime() > config.commitTimeS * 1000) {
                         try(Timer.Context context = metrics.stateCommitted.time()) {
-                            logger.info("Performing a full commit");
+                            logger.info("Performing a time based commit");
                             calculateRecordsToCreate();
                             calculateTotalLag();
                             commit();
-                            commitWatch.reset();
-                            commitWatch.start();
                         }
                     }
                 } while (topicLag > config.topicLagTrigger);
@@ -396,6 +402,7 @@ public class Southpaw {
      * Commit / flush offsets and data for the normalized topics and indices
      */
     public void commit() {
+        logger.info("Committing southpaw state");
         // Commit / flush changes
         for(Map.Entry<String, BaseTopic<byte[], DenormalizedRecord>> topic: outputTopics.entrySet()) {
             topic.getValue().flush();
@@ -411,6 +418,11 @@ public class Southpaw {
             entry.getValue().commit();
         }
         state.flush();
+
+        // Commit performed. Reset timer
+        commitWatch.reset();
+        commitWatch.start();
+        logger.info("Finished committing southpaw state");
     }
 
     /**


### PR DESCRIPTION
This adjusts the commit timer functionality to roughly ensure a commit occurs at least once every `commit.time.s` seconds since the last commit. Currently this timer functions as a wall clock commit every `commit.time.s` seconds regardless of how recently a commit was performed. In cases where the `commit.time.s` and `backup.time.s` wall clock times overlap such as commit every 300 seconds, backup every 600 seconds, we would previously perform commit -> backup + commit -> commit because the timers would overlap so the subsequent loop after backing up and committing would trip off the commit timer. This adjusts the timer to be less aggressive and only kick in when we haven't committed for roughly max `commit.time.s` seconds since we call `commit()` multiple places within the main `build()` loop.

This also adds some more logging around commit / backup start/stop as well as wrapping the commit time metric within the `commit()` function instead of just the timer based commit