### PR TITLE
Bump Guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <version.commons.lang>2.6</version.commons.lang>
         <version.confluent>4.0.0</version.confluent>
         <version.dropwizard>4.0.2</version.dropwizard>
-        <version.guava>29.0-jre</version.guava>
+        <version.guava>30.0-jre</version.guava>
         <version.jackson>2.11.1</version.jackson>
         <version.jopt.simple>4.9</version.jopt.simple>
         <version.kafka>1.0.0</version.kafka>


### PR DESCRIPTION
This PR bumps the Guava version to resolve a Dependencybot alert. We don't use the affected method, so older Southpaw versions do not have a vulnerability, but it's still nice to resolve the alert.