### PR TITLE
exclude checkstyle on auto-generated classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,8 +224,9 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <encoding>UTF-8</encoding>
                     <configLocation>src/checkstyle/google_checks.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <excludes>com/jwplayer/southpaw/json/*</excludes>
                     <linkXRef>false</linkXRef>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Excludes checkstyle from checking auto generated json classes